### PR TITLE
Add Conductor workspace configuration

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,9 @@
+#:schema https://conductor.build/schemas/settings.repo.schema.json
+
+# Shared, committed Conductor config — the team baseline. Personal overrides
+# live in the gitignored .conductor/settings.local.toml, which takes precedence.
+
+[scripts]
+setup = "bin/setup --skip-server"
+run = "PORT=$CONDUCTOR_PORT bin/dev"
+run_mode = "concurrent"

--- a/.conductor/setup.sh
+++ b/.conductor/setup.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Conductor workspace setup.
+#
+# Copies gitignored local files from the repo's primary tree (root) into this
+# workspace, then runs the app's standard bootstrap. New worktrees don't inherit
+# gitignored files, so we copy them from $CONDUCTOR_ROOT_PATH here.
+set -euo pipefail
+
+ROOT="${CONDUCTOR_ROOT_PATH:-}"
+
+if [ -n "$ROOT" ] && [ "$ROOT" != "$PWD" ]; then
+  # Personal Conductor settings (gitignored).
+  if [ -f "$ROOT/.conductor/settings.local.toml" ]; then
+    mkdir -p .conductor
+    cp "$ROOT/.conductor/settings.local.toml" .conductor/settings.local.toml
+  fi
+
+  # Rails credential keys (gitignored): config/master.key and any
+  # per-environment keys under config/credentials/*.key.
+  for key in "$ROOT"/config/*.key "$ROOT"/config/credentials/*.key; do
+    [ -e "$key" ] || continue
+    dest="config/${key#"$ROOT"/config/}"
+    mkdir -p "$(dirname "$dest")"
+    cp "$key" "$dest"
+  done
+fi
+
+# Standard app bootstrap: install gems and prepare the DB, without starting a server.
+exec bin/setup --skip-server

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Ignore bundler config.
 /.bundle
 
+# Ignore personal Conductor settings (copied into each workspace by .conductor/setup.sh).
+/.conductor/settings.local.toml
+
 # Ignore all environment files.
 /.env*
 


### PR DESCRIPTION
Adds Conductor configuration so each workspace can bootstrap and run the Rails app on its own port. The committed `.conductor/settings.toml` defines `setup`/`run`/`run_mode` (concurrent) as the shared team baseline, using the app's own `bin/setup --skip-server` and `bin/dev` on `CONDUCTOR_PORT`. A gitignored `.conductor/settings.local.toml` (excluded via `.gitignore`) overrides `setup` to `.conductor/setup.sh`, which copies gitignored local files — Rails credential keys and the local settings — from the repo root into each new workspace before bootstrapping. The new `.conductor/setup.sh` is committed and tolerant of those files being absent.