### PR TITLE
Add giving scenarios with ongoing and one-time allocations

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -1,0 +1,27 @@
+class AllocationsController < ApplicationController
+  before_action :set_scenario
+
+  def create
+    allocation = @scenario.allocations.create(allocation_params)
+    if allocation.persisted?
+      redirect_to scenario_path(@scenario)
+    else
+      redirect_to scenario_path(@scenario), alert: allocation.errors.full_messages.to_sentence
+    end
+  end
+
+  def destroy
+    @scenario.allocations.find(params[:id]).destroy
+    redirect_to scenario_path(@scenario)
+  end
+
+  private
+
+  def set_scenario
+    @scenario = Current.user.scenarios.where(organization: Current.organization).find(params[:scenario_id])
+  end
+
+  def allocation_params
+    params.require(:allocation).permit(:option, :percentage, :amount, :note, :type)
+  end
+end

--- a/app/controllers/scenarios_controller.rb
+++ b/app/controllers/scenarios_controller.rb
@@ -1,0 +1,50 @@
+class ScenariosController < ApplicationController
+  before_action :set_scenario, only: %i[ show update destroy ]
+
+  def index
+    @scenarios = scenarios.order(created_at: :desc)
+  end
+
+  def show
+  end
+
+  def new
+    @scenario = scenarios.new
+  end
+
+  def create
+    @scenario = scenarios.new(scenario_params)
+    if @scenario.save
+      redirect_to scenario_path(@scenario)
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @scenario.update(scenario_params)
+      redirect_to scenario_path(@scenario)
+    else
+      render :show, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @scenario.destroy
+    redirect_to scenarios_path
+  end
+
+  private
+
+  def scenarios
+    Current.user.scenarios.where(organization: Current.organization)
+  end
+
+  def set_scenario
+    @scenario = scenarios.find(params[:id])
+  end
+
+  def scenario_params
+    params.require(:scenario).permit(:name, :total_giving_amount)
+  end
+end

--- a/app/javascript/controllers/dialog_controller.js
+++ b/app/javascript/controllers/dialog_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Opens/closes the <dialog> target within this controller's scope.
+// Trigger with data-action="dialog#open" / "dialog#close".
+export default class extends Controller {
+  static targets = ["dialog"]
+
+  open() {
+    this.dialogTarget.showModal()
+  }
+
+  close() {
+    this.dialogTarget.close()
+  }
+}

--- a/app/javascript/controllers/range_controller.js
+++ b/app/javascript/controllers/range_controller.js
@@ -1,0 +1,10 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Mirrors a range input's value into an output element as it moves.
+export default class extends Controller {
+  static targets = ["input", "output"]
+
+  update() {
+    this.outputTarget.textContent = this.inputTarget.value
+  }
+}

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -1,0 +1,5 @@
+class Allocation < ApplicationRecord
+  belongs_to :scenario
+
+  validates :option, presence: true
+end

--- a/app/models/allocation/one_time.rb
+++ b/app/models/allocation/one_time.rb
@@ -1,0 +1,25 @@
+class Allocation::OneTime < Allocation
+  validates :amount,
+    presence: true,
+    numericality: { greater_than: 0 }
+  validate :within_total_giving_amount
+
+  def ongoing?
+    false
+  end
+
+  def one_time?
+    true
+  end
+
+  private
+
+  def within_total_giving_amount
+    return if amount.blank? || scenario&.total_giving_amount.blank?
+
+    others = scenario.one_time_allocations.where.not(id: id).sum(:amount)
+    if others + amount > scenario.total_giving_amount
+      errors.add(:amount, "would bring one-time giving to #{others + amount}, over the total giving amount of #{scenario.total_giving_amount.to_i}")
+    end
+  end
+end

--- a/app/models/allocation/ongoing.rb
+++ b/app/models/allocation/ongoing.rb
@@ -1,0 +1,13 @@
+class Allocation::Ongoing < Allocation
+  validates :percentage,
+    presence: true,
+    numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 100 }
+
+  def ongoing?
+    true
+  end
+
+  def one_time?
+    false
+  end
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,6 +1,7 @@
 class Organization < ApplicationRecord
   has_many :organization_memberships, dependent: :destroy
   has_many :users, through: :organization_memberships
+  has_many :scenarios, dependent: :destroy
 
   normalizes :subdomain, with: ->(s) { s.strip.downcase }
 

--- a/app/models/scenario.rb
+++ b/app/models/scenario.rb
@@ -1,0 +1,13 @@
+class Scenario < ApplicationRecord
+  belongs_to :organization
+  belongs_to :user
+  has_many :allocations, dependent: :destroy
+  has_many :ongoing_allocations, class_name: "Allocation::Ongoing"
+  has_many :one_time_allocations, class_name: "Allocation::OneTime"
+
+  validates :name, presence: true
+
+  def ongoing_percentage_total
+    ongoing_allocations.sum { |allocation| allocation.percentage.to_i }
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
   has_many :sessions, dependent: :destroy
   has_many :organization_memberships, dependent: :destroy
   has_many :organizations, through: :organization_memberships
+  has_many :scenarios, dependent: :destroy
 
   generates_token_for :email_confirmation, expires_in: 1.day do
     confirmed_at

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -6,7 +6,8 @@
     <p class="mt-3 text-gray-500">You're signed in to <%= Current.organization.name %>.</p>
 
     <div class="mt-8 flex items-center justify-center gap-4">
-      <%= button_to "Sign out", session_path, method: :delete, class: "rounded-md px-3.5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white font-medium cursor-pointer" %>
+      <%= link_to "Explore options", scenarios_path, class: "rounded-md px-3.5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white font-medium inline-block" %>
+      <%= button_to "Sign out", session_path, method: :delete, class: "rounded-md px-3.5 py-2.5 border border-gray-400 hover:bg-gray-50 text-gray-700 font-medium cursor-pointer" %>
     </div>
   <% else %>
     <h1 class="font-bold text-4xl tracking-tight text-gray-900">Welcome to <%= Current.organization.name %></h1>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,8 +24,11 @@
   </head>
 
   <body>
-    <main class="container mx-auto mt-28 px-5 flex">
-      <%= yield %>
-    </main>
+    <div class="container mx-auto mt-8 px-5">
+      <%= render "shared/flash" %>
+      <main class="flex">
+        <%= yield %>
+      </main>
+    </div>
   </body>
 </html>

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -1,8 +1,4 @@
 <div class="mx-auto md:w-2/3 w-full">
-  <% if alert = flash[:alert] %>
-    <p class="py-2 px-3 bg-red-50 mb-5 text-red-500 font-medium rounded-lg inline-block" id="alert"><%= alert %></p>
-  <% end %>
-
   <h1 class="font-bold text-4xl">Update your password</h1>
 
   <%= form_with url: password_path(params[:token]), method: :put, class: "contents" do |form| %>

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -1,8 +1,4 @@
 <div class="mx-auto md:w-2/3 w-full">
-  <% if alert = flash[:alert] %>
-    <p class="py-2 px-3 bg-red-50 mb-5 text-red-500 font-medium rounded-lg inline-block" id="alert"><%= alert %></p>
-  <% end %>
-
   <h1 class="font-bold text-4xl">Forgot your password?</h1>
 
   <%= form_with url: passwords_path, class: "contents" do |form| %>

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -1,8 +1,4 @@
 <div class="mx-auto md:w-2/3 w-full">
-  <% if alert = flash[:alert] %>
-    <p class="py-2 px-3 bg-red-50 mb-5 text-red-500 font-medium rounded-lg inline-block" id="alert"><%= alert %></p>
-  <% end %>
-
   <h1 class="font-bold text-4xl">Sign up</h1>
 
   <%= form_with model: @user, url: registration_url, class: "contents" do |form| %>

--- a/app/views/scenarios/_allocation.html.erb
+++ b/app/views/scenarios/_allocation.html.erb
@@ -1,0 +1,16 @@
+<div class="flex items-start justify-between gap-3 rounded-lg border border-gray-200 px-4 py-3">
+  <div class="min-w-0">
+    <p class="font-medium text-gray-900 truncate"><%= allocation.option %></p>
+    <% if allocation.note.present? %>
+      <p class="mt-1 text-sm text-gray-500"><%= allocation.note %></p>
+    <% end %>
+  </div>
+  <div class="flex items-center gap-3 shrink-0">
+    <span class="font-semibold text-gray-900">
+      <%= allocation.ongoing? ? "#{allocation.percentage}%" : number_to_currency(allocation.amount) %>
+    </span>
+    <%= button_to "✕", scenario_allocation_path(allocation.scenario, allocation), method: :delete,
+          class: "text-gray-400 hover:text-red-500 cursor-pointer bg-transparent p-0 leading-none",
+          data: { turbo_confirm: "Remove this allocation?" } %>
+  </div>
+</div>

--- a/app/views/scenarios/_allocation_modal.html.erb
+++ b/app/views/scenarios/_allocation_modal.html.erb
@@ -1,0 +1,49 @@
+<% suffix = klass.model_name.element %>
+<dialog data-dialog-target="dialog" class="m-auto w-full max-w-lg rounded-2xl p-0 backdrop:bg-black/30">
+  <%= form_with url: scenario_allocations_path(@scenario), class: "p-8" do |form| %>
+    <%= hidden_field_tag "allocation[type]", klass.name %>
+    <h2 class="font-bold text-2xl text-gray-900">Create allocation</h2>
+
+    <div class="mt-6">
+      <%= label_tag "allocation_option_#{suffix}", "Option", class: "block text-sm text-gray-600" %>
+      <%= text_field_tag "allocation[option]", nil, id: "allocation_option_#{suffix}", required: true,
+            class: "mt-1 block w-full rounded-md border border-gray-400 focus:outline-blue-600 px-3 py-2 shadow-sm" %>
+    </div>
+
+    <% if klass == Allocation::Ongoing %>
+      <div class="mt-6" data-controller="range">
+        <div class="flex items-center justify-between">
+          <span class="text-sm text-gray-600">Giving percentage %</span>
+          <span class="text-sm text-gray-400">100 % reminder</span>
+        </div>
+        <p class="mt-1 text-lg font-medium text-gray-900"><span data-range-target="output">20</span> %</p>
+        <%= range_field_tag "allocation[percentage]", 20, min: 0, max: 100, step: 1,
+              data: { range_target: "input", action: "input->range#update" },
+              class: "mt-2 w-full" %>
+      </div>
+    <% else %>
+      <div class="mt-6">
+        <%= label_tag "allocation_amount_#{suffix}", "Amount", class: "block text-sm text-gray-600" %>
+        <div class="relative mt-1">
+          <span class="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">$</span>
+          <%= number_field_tag "allocation[amount]", nil, id: "allocation_amount_#{suffix}", min: 0, step: "0.01", required: true, placeholder: "0.00",
+                class: "block w-full rounded-md border border-gray-400 focus:outline-blue-600 pl-7 pr-3 py-2 shadow-sm" %>
+        </div>
+      </div>
+    <% end %>
+
+    <div class="mt-6">
+      <%= label_tag "allocation_note_#{suffix}", "Note (optional)", class: "block text-sm text-gray-600" %>
+      <%= text_area_tag "allocation[note]", nil, id: "allocation_note_#{suffix}", rows: 3, placeholder: "Extra preferences",
+            class: "mt-1 block w-full rounded-md border border-gray-400 focus:outline-blue-600 px-3 py-2 shadow-sm" %>
+    </div>
+
+    <div class="mt-8 flex justify-end gap-3">
+      <button type="button" data-action="dialog#close"
+              class="rounded-md border border-gray-300 px-5 py-2.5 font-medium text-gray-700 hover:bg-gray-50 cursor-pointer">
+        Cancel
+      </button>
+      <%= form.submit "Create", class: "rounded-md px-5 py-2.5 bg-gray-700 hover:bg-gray-600 text-white font-medium cursor-pointer" %>
+    </div>
+  <% end %>
+</dialog>

--- a/app/views/scenarios/_allocation_section.html.erb
+++ b/app/views/scenarios/_allocation_section.html.erb
@@ -1,0 +1,22 @@
+<div class="mt-6" data-controller="dialog">
+  <div class="flex items-center justify-between">
+    <h3 class="font-semibold text-gray-900"><%= title %></h3>
+    <button type="button"
+            data-action="dialog#open"
+            class="rounded-md px-3 py-1.5 text-sm font-medium bg-gray-700 hover:bg-gray-600 text-white cursor-pointer">
+      Add allocation
+    </button>
+  </div>
+
+  <% if allocations.any? %>
+    <div class="mt-3 space-y-2">
+      <%= render partial: "allocation", collection: allocations %>
+    </div>
+  <% else %>
+    <div class="mt-3 rounded-lg border border-gray-200 bg-gray-50 py-12 text-center text-gray-500">
+      Start to create allocation
+    </div>
+  <% end %>
+
+  <%= render "allocation_modal", klass: klass %>
+</div>

--- a/app/views/scenarios/index.html.erb
+++ b/app/views/scenarios/index.html.erb
@@ -1,0 +1,38 @@
+<div class="mx-auto max-w-4xl w-full px-4 py-12">
+  <div class="flex items-start justify-between gap-4">
+    <div>
+      <h1 class="font-bold text-4xl tracking-tight text-gray-900">Explore options</h1>
+      <p class="mt-3 max-w-xl text-gray-500">
+        Explore different ways to allocate your giving. Create scenarios to see how your support could
+        be distributed across programs, populations, and organizations.
+      </p>
+    </div>
+    <%= link_to "Create scenario", new_scenario_path,
+          class: "shrink-0 rounded-md px-3.5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white font-medium inline-block" %>
+  </div>
+
+  <% if @scenarios.any? %>
+    <div class="mt-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      <% @scenarios.each do |scenario| %>
+        <div class="rounded-xl border border-gray-200 p-5 hover:shadow-sm transition">
+          <div class="flex items-center justify-between">
+            <%= link_to scenario.name, scenario_path(scenario), class: "font-semibold text-lg text-gray-900 hover:text-blue-600" %>
+          </div>
+          <p class="mt-2 text-gray-500">
+            <%= scenario.total_giving_amount.present? ? number_to_currency(scenario.total_giving_amount) : "No total set" %>
+          </p>
+          <div class="mt-4 flex items-center gap-3 text-sm">
+            <%= link_to "Open", scenario_path(scenario), class: "text-blue-600 hover:underline" %>
+            <%= button_to "Delete", scenario_path(scenario), method: :delete,
+                  class: "text-red-500 hover:underline cursor-pointer bg-transparent p-0",
+                  data: { turbo_confirm: "Delete this scenario?" } %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% else %>
+    <div class="mt-10 rounded-xl border border-dashed border-gray-300 py-20 text-center text-gray-500">
+      No scenarios yet. Create one to start exploring.
+    </div>
+  <% end %>
+</div>

--- a/app/views/scenarios/new.html.erb
+++ b/app/views/scenarios/new.html.erb
@@ -1,0 +1,26 @@
+<div class="mx-auto max-w-xl w-full px-4 py-12">
+  <%= link_to "← Back to explore options", scenarios_path,
+        class: "inline-block rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50" %>
+
+  <h1 class="mt-6 font-bold text-3xl tracking-tight text-gray-900">New scenario</h1>
+  <p class="mt-2 text-gray-500">Give your scenario a name to get started. You'll set the giving amount and add allocations next.</p>
+
+  <%= form_with model: @scenario, class: "contents" do |form| %>
+    <% if @scenario.errors.any? %>
+      <p class="mt-5 py-2 px-3 bg-red-50 text-red-500 font-medium rounded-lg inline-block">
+        <%= @scenario.errors.full_messages.to_sentence %>
+      </p>
+    <% end %>
+
+    <div class="mt-6">
+      <%= form.label :name, class: "block text-gray-600" %>
+      <%= form.text_field :name, required: true, autofocus: true, placeholder: "e.g. Education focus",
+            class: "mt-2 block w-full rounded-md border border-gray-400 focus:outline-blue-600 px-3 py-2 shadow-sm" %>
+    </div>
+
+    <div class="mt-6 flex items-center gap-3">
+      <%= form.submit "Create scenario", class: "rounded-md px-3.5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white font-medium cursor-pointer" %>
+      <%= link_to "Cancel", scenarios_path, class: "text-gray-600 hover:underline" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/scenarios/show.html.erb
+++ b/app/views/scenarios/show.html.erb
@@ -1,0 +1,86 @@
+<div class="mx-auto max-w-5xl w-full px-4 py-10">
+  <%= link_to "← Back to explore options", scenarios_path,
+        class: "inline-block rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50" %>
+
+  <h1 class="mt-6 font-bold text-3xl tracking-tight text-gray-900"><%= @scenario.name %></h1>
+
+  <%= form_with model: @scenario, class: "contents" do |form| %>
+    <div class="mt-6 flex items-center gap-4">
+      <%= form.label :name, class: "w-40 text-gray-600" %>
+      <%= form.text_field :name, required: true,
+            class: "max-w-md w-full block rounded-md border border-gray-400 focus:outline-blue-600 px-3 py-2 shadow-sm" %>
+    </div>
+
+    <div class="mt-4 flex items-center gap-4">
+      <%= form.label :total_giving_amount, "Total giving amount", class: "w-40 text-gray-600" %>
+      <div class="relative max-w-md w-full">
+        <span class="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">$</span>
+        <%= form.number_field :total_giving_amount, step: "0.01", min: 0, placeholder: "0.00",
+              class: "block w-full rounded-md border border-gray-400 focus:outline-blue-600 pl-7 pr-3 py-2 shadow-sm" %>
+      </div>
+    </div>
+
+    <div class="mt-4 flex items-center gap-4">
+      <span class="w-40"></span>
+      <%= form.submit "Save", class: "rounded-md px-3 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium cursor-pointer" %>
+    </div>
+  <% end %>
+
+  <div class="mt-8 grid gap-6 lg:grid-cols-2">
+    <!-- Allocations -->
+    <div class="rounded-xl border border-gray-200 p-6">
+      <h2 class="font-bold text-xl text-gray-900">Allocations</h2>
+
+      <%= render "allocation_section",
+            title: "On going giving",
+            klass: Allocation::Ongoing,
+            allocations: @scenario.ongoing_allocations %>
+
+      <%= render "allocation_section",
+            title: "One time giving",
+            klass: Allocation::OneTime,
+            allocations: @scenario.one_time_allocations %>
+    </div>
+
+    <!-- Summary -->
+    <div class="rounded-xl border border-gray-200 p-6">
+      <h2 class="font-bold text-xl text-gray-900">Allocation summary</h2>
+
+      <div class="mt-5">
+        <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500">On going giving</h3>
+        <% if @scenario.ongoing_allocations.any? %>
+          <ul class="mt-3 space-y-2">
+            <% @scenario.ongoing_allocations.each do |allocation| %>
+              <li class="flex justify-between text-gray-700">
+                <span><%= allocation.option %></span>
+                <span class="font-medium"><%= allocation.percentage %>%</span>
+              </li>
+            <% end %>
+          </ul>
+          <% total = @scenario.ongoing_percentage_total %>
+          <p class="mt-3 text-sm font-medium <%= total == 100 ? "text-green-600" : "text-gray-500" %>">
+            <%= total %>% of 100%<%= " — add #{100 - total}% more" if total < 100 %><%= " — #{total - 100}% over" if total > 100 %>
+          </p>
+        <% else %>
+          <p class="mt-3 text-gray-400">No ongoing allocations yet.</p>
+        <% end %>
+      </div>
+
+      <div class="mt-6">
+        <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500">One time giving</h3>
+        <% if @scenario.one_time_allocations.any? %>
+          <ul class="mt-3 space-y-2">
+            <% @scenario.one_time_allocations.each do |allocation| %>
+              <li class="flex justify-between text-gray-700">
+                <span><%= allocation.option %></span>
+                <span class="font-medium"><%= number_to_currency(allocation.amount) %></span>
+              </li>
+            <% end %>
+          </ul>
+        <% else %>
+          <p class="mt-3 text-gray-400">No one-time allocations yet.</p>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,12 +1,4 @@
 <div class="mx-auto md:w-2/3 w-full">
-  <% if alert = flash[:alert] %>
-    <p class="py-2 px-3 bg-red-50 mb-5 text-red-500 font-medium rounded-lg inline-block" id="alert"><%= alert %></p>
-  <% end %>
-
-  <% if notice = flash[:notice] %>
-    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
-  <% end %>
-
   <h1 class="font-bold text-4xl">Sign in</h1>
 
   <%= form_with url: session_url, class: "contents" do |form| %>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,0 +1,6 @@
+<% flash.each do |type, message| %>
+  <% next if message.blank? %>
+  <p id="<%= type %>" class="mb-5 py-2 px-3 font-medium rounded-lg inline-block <%= type.to_s == "alert" ? "bg-red-50 text-red-500" : "bg-green-50 text-green-600" %>">
+    <%= message %>
+  </p>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,10 @@ Rails.application.routes.draw do
   resource :email_confirmation, only: :show
   resource :session
 
+  resources :scenarios do
+    resources :allocations, only: %i[ create destroy ]
+  end
+
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check

--- a/db/migrate/20260610120000_create_scenarios.rb
+++ b/db/migrate/20260610120000_create_scenarios.rb
@@ -1,0 +1,12 @@
+class CreateScenarios < ActiveRecord::Migration[8.1]
+  def change
+    create_table :scenarios do |t|
+      t.references :organization, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.string :name, null: false
+      t.decimal :total_giving_amount, precision: 12, scale: 2
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260610120001_create_allocations.rb
+++ b/db/migrate/20260610120001_create_allocations.rb
@@ -1,0 +1,14 @@
+class CreateAllocations < ActiveRecord::Migration[8.1]
+  def change
+    create_table :allocations do |t|
+      t.references :scenario, null: false, foreign_key: true
+      t.string :type, null: false
+      t.string :option, null: false
+      t.integer :percentage
+      t.decimal :amount, precision: 12, scale: 2
+      t.text :note
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_10_114242) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_10_120001) do
+  create_table "allocations", force: :cascade do |t|
+    t.integer "scenario_id", null: false
+    t.string "type", null: false
+    t.string "option", null: false
+    t.integer "percentage"
+    t.decimal "amount", precision: 12, scale: 2
+    t.text "note"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["scenario_id"], name: "index_allocations_on_scenario_id"
+  end
+
   create_table "organization_memberships", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "organization_id", null: false
@@ -28,6 +40,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_10_114242) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["subdomain"], name: "index_organizations_on_subdomain", unique: true
+  end
+
+  create_table "scenarios", force: :cascade do |t|
+    t.integer "organization_id", null: false
+    t.integer "user_id", null: false
+    t.string "name", null: false
+    t.decimal "total_giving_amount", precision: 12, scale: 2
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["organization_id"], name: "index_scenarios_on_organization_id"
+    t.index ["user_id"], name: "index_scenarios_on_user_id"
   end
 
   create_table "sessions", force: :cascade do |t|
@@ -48,7 +71,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_10_114242) do
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end
 
+  add_foreign_key "allocations", "scenarios"
   add_foreign_key "organization_memberships", "organizations"
   add_foreign_key "organization_memberships", "users"
+  add_foreign_key "scenarios", "organizations"
+  add_foreign_key "scenarios", "users"
   add_foreign_key "sessions", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,3 +19,18 @@ arlington = Organization.find_or_create_by!(subdomain: "arlington") do |org|
 end
 
 OrganizationMembership.find_or_create_by!(user: user, organization: arlington)
+
+balanced = user.scenarios.find_or_create_by!(organization: arlington, name: "Balanced giving") do |scenario|
+  scenario.total_giving_amount = 10_000
+end
+
+if balanced.allocations.empty?
+  balanced.ongoing_allocations.create!(option: "Greatest Community Need", percentage: 30)
+  balanced.ongoing_allocations.create!(option: "Program: Education", percentage: 30)
+  balanced.ongoing_allocations.create!(option: "Population: Youth", percentage: 40)
+  balanced.one_time_allocations.create!(option: "Specific org", amount: 1_000)
+end
+
+user.scenarios.find_or_create_by!(organization: arlington, name: "Education focus") do |scenario|
+  scenario.total_giving_amount = 5_000
+end

--- a/test/controllers/allocations_controller_test.rb
+++ b/test/controllers/allocations_controller_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+
+class AllocationsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    host! "arlington.localhost"
+    sign_in_as users(:one)
+    @scenario = scenarios(:one_arlington)
+  end
+
+  test "creates an ongoing allocation" do
+    assert_difference -> { @scenario.allocations.count }, 1 do
+      post scenario_allocations_url(@scenario), params: {
+        allocation: { type: "Allocation::Ongoing", option: "Population: Youth", percentage: 25 }
+      }
+    end
+    assert_redirected_to scenario_path(@scenario)
+  end
+
+  test "creates a one time allocation" do
+    assert_difference -> { @scenario.allocations.count }, 1 do
+      post scenario_allocations_url(@scenario), params: {
+        allocation: { type: "Allocation::OneTime", option: "Specific org", amount: 1000 }
+      }
+    end
+    assert_redirected_to scenario_path(@scenario)
+  end
+
+  test "rejects a one_time allocation that exceeds the total giving amount" do
+    # scenario total is 10000 and education_grant fixture already allocates 5000.
+    assert_no_difference -> { @scenario.allocations.count } do
+      post scenario_allocations_url(@scenario), params: {
+        allocation: { type: "Allocation::OneTime", option: "Too big", amount: 6000 }
+      }
+    end
+    assert_redirected_to scenario_path(@scenario)
+    assert flash[:alert].present?
+  end
+
+  test "destroys an allocation" do
+    assert_difference -> { @scenario.allocations.count }, -1 do
+      delete scenario_allocation_url(@scenario, allocations(:greatest_need))
+    end
+    assert_redirected_to scenario_path(@scenario)
+  end
+
+  test "cannot add an allocation to a scenario you do not own" do
+    assert_no_difference -> { Allocation.count } do
+      post scenario_allocations_url(scenarios(:two_boston)), params: {
+        allocation: { type: "Allocation::Ongoing", option: "X", percentage: 10 }
+      }
+    end
+    assert_response :not_found
+  end
+end

--- a/test/controllers/scenarios_controller_test.rb
+++ b/test/controllers/scenarios_controller_test.rb
@@ -1,0 +1,66 @@
+require "test_helper"
+
+class ScenariosControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    host! "arlington.localhost"
+    sign_in_as users(:one)
+  end
+
+  test "index lists the donor's scenarios" do
+    get scenarios_url
+    assert_response :success
+    assert_select "h1", "Explore options"
+    assert_match scenarios(:one_arlington).name, response.body
+  end
+
+  test "requires authentication" do
+    sign_out
+    get scenarios_url
+    assert_redirected_to new_session_path
+  end
+
+  test "new renders the scenario form" do
+    get new_scenario_url
+    assert_response :success
+    assert_select "form"
+  end
+
+  test "create makes a named scenario for the current donor and org" do
+    assert_difference -> { users(:one).scenarios.count }, 1 do
+      post scenarios_url, params: { scenario: { name: "Education focus" } }
+    end
+    scenario = users(:one).scenarios.order(:created_at).last
+    assert_equal "Education focus", scenario.name
+    assert_equal organizations(:arlington), scenario.organization
+    assert_redirected_to scenario_path(scenario)
+  end
+
+  test "create re-renders the form when name is blank" do
+    assert_no_difference -> { Scenario.count } do
+      post scenarios_url, params: { scenario: { name: "" } }
+    end
+    assert_response :unprocessable_entity
+  end
+
+  test "show renders an owned scenario" do
+    get scenario_url(scenarios(:one_arlington))
+    assert_response :success
+  end
+
+  test "update changes total giving amount" do
+    patch scenario_url(scenarios(:one_arlington)), params: { scenario: { total_giving_amount: 2500 } }
+    assert_equal 2500, scenarios(:one_arlington).reload.total_giving_amount
+  end
+
+  test "destroy removes the scenario" do
+    assert_difference -> { Scenario.count }, -1 do
+      delete scenario_url(scenarios(:one_arlington))
+    end
+    assert_redirected_to scenarios_path
+  end
+
+  test "cannot access a scenario owned by another user or org" do
+    get scenario_url(scenarios(:two_boston))
+    assert_response :not_found
+  end
+end

--- a/test/fixtures/allocations.yml
+++ b/test/fixtures/allocations.yml
@@ -1,0 +1,11 @@
+greatest_need:
+  scenario: one_arlington
+  type: Allocation::Ongoing
+  option: Greatest Community Need
+  percentage: 30
+
+education_grant:
+  scenario: one_arlington
+  type: Allocation::OneTime
+  option: "Program: Education"
+  amount: 5000

--- a/test/fixtures/scenarios.yml
+++ b/test/fixtures/scenarios.yml
@@ -1,0 +1,11 @@
+one_arlington:
+  user: one
+  organization: arlington
+  name: Scenario 1
+  total_giving_amount: 10000
+
+two_boston:
+  user: two
+  organization: boston
+  name: Boston plan
+  total_giving_amount: 5000

--- a/test/models/allocation_test.rb
+++ b/test/models/allocation_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+class AllocationTest < ActiveSupport::TestCase
+  setup { @scenario = scenarios(:one_arlington) }
+
+  test "requires an option" do
+    allocation = @scenario.ongoing_allocations.new(percentage: 10, option: "")
+    assert_not allocation.valid?
+    assert_includes allocation.errors[:option], "can't be blank"
+  end
+
+  test "ongoing requires a percentage between 0 and 100" do
+    assert_not @scenario.ongoing_allocations.new(option: "X").valid?
+    assert_not @scenario.ongoing_allocations.new(option: "X", percentage: 150).valid?
+    assert @scenario.ongoing_allocations.new(option: "X", percentage: 25).valid?
+  end
+
+  test "one_time requires a positive amount" do
+    assert_not @scenario.one_time_allocations.new(option: "X").valid?
+    assert_not @scenario.one_time_allocations.new(option: "X", amount: 0).valid?
+    assert @scenario.one_time_allocations.new(option: "X", amount: 100).valid?
+  end
+
+  test "ongoing does not require an amount" do
+    assert @scenario.ongoing_allocations.new(option: "X", percentage: 10).valid?
+  end
+
+  test "one_time allocations cannot exceed the total giving amount" do
+    # scenario total is 10000 and education_grant fixture already allocates 5000.
+    assert_not @scenario.one_time_allocations.new(option: "Too much", amount: 5001).valid?
+    assert @scenario.one_time_allocations.new(option: "Just fits", amount: 5000).valid?
+  end
+
+  test "kind predicates reflect the subclass" do
+    assert allocations(:greatest_need).ongoing?
+    assert_not allocations(:greatest_need).one_time?
+    assert allocations(:education_grant).one_time?
+  end
+end

--- a/test/models/scenario_test.rb
+++ b/test/models/scenario_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+
+class ScenarioTest < ActiveSupport::TestCase
+  test "requires a name" do
+    scenario = Scenario.new(name: "")
+    assert_not scenario.valid?
+    assert_includes scenario.errors[:name], "can't be blank"
+  end
+
+  test "splits allocations by kind" do
+    scenario = scenarios(:one_arlington)
+    assert_includes scenario.ongoing_allocations, allocations(:greatest_need)
+    assert_includes scenario.one_time_allocations, allocations(:education_grant)
+  end
+
+  test "ongoing_percentage_total sums ongoing percentages" do
+    assert_equal 30, scenarios(:one_arlington).ongoing_percentage_total
+  end
+
+  test "destroys dependent allocations" do
+    scenario = scenarios(:one_arlington)
+    assert_difference -> { Allocation.count }, -2 do
+      scenario.destroy
+    end
+  end
+end


### PR DESCRIPTION
Adds a donor-facing "Explore options" feature: users create named **scenarios** (private to the user within their organization), set a total giving amount, and add **allocations** split into percentage-based "on going giving" and dollar-based "one time giving". Allocations use single table inheritance (`Allocation::Ongoing` / `Allocation::OneTime`), and one-time gifts are validated to not exceed the scenario's total giving amount. The feature ships full scenarios/allocations CRUD, a basic allocation summary with a running "% of 100%" reminder, native `<dialog>` modal forms driven by small Stimulus controllers, and seed data. Also refactors flash rendering into a shared layout-level partial (removing the inline blocks across the auth views) and trims the oversized top margin in the layout. Covered by model and controller tests, including per-user/per-org scoping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)