### PR TITLE
Restyle app with warm editorial theme

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,1 +1,32 @@
 @import "tailwindcss";
+
+@theme {
+  --color-canvas: #F5F2ED;
+  --color-surface: #FFFFFF;
+  --color-surface-soft: #FAF8F5;
+  --color-line: #E5E0D6;
+  --color-line-soft: #EDE9E2;
+  --color-ink: #1A1814;
+  --color-ink-soft: #6E6960;
+  --color-ink-faint: #ABA59D;
+  --color-accent: #2A2A2A;         /* primary buttons */
+  --color-brand: #E07B39;          /* warm orange accent */
+  --color-brand-tint: #FFF8F0;     /* warm tinted surface */
+  --color-success: #1A7A5E;
+  --color-success-tint: #EAF4F0;
+  --color-warn: #8A5200;
+  --color-warn-tint: #FEF6E7;
+  --color-danger: #C0392B;
+  --color-danger-tint: #FEF0EE;
+
+  --font-sans: "DM Sans", ui-sans-serif, system-ui, sans-serif;
+  --font-serif: "Lora", ui-serif, Georgia, serif;
+}
+
+@layer base {
+  body {
+    background-color: var(--color-canvas);
+    color: var(--color-ink);
+    font-family: var(--font-sans);
+  }
+}

--- a/app/views/home/landing.html.erb
+++ b/app/views/home/landing.html.erb
@@ -1,16 +1,16 @@
 <div class="mx-auto max-w-xl w-full px-4 py-16 text-center">
-  <h1 class="font-bold text-4xl tracking-tight text-gray-900">Community Foundations</h1>
-  <p class="mt-3 text-gray-500">Visit one of the community foundation pages to sign in or create an account.</p>
+  <h1 class="font-serif font-medium text-4xl tracking-tight text-ink">Community Foundations</h1>
+  <p class="mt-3 text-ink-soft">Visit one of the community foundation pages to sign in or create an account.</p>
 
   <% if @organizations.any? %>
     <ul class="mt-8 flex flex-col items-center gap-3">
       <% @organizations.each do |organization| %>
         <li>
-          <%= link_to organization.name, root_url(subdomain: organization.subdomain), class: "text-blue-600 hover:text-blue-500 font-medium" %>
+          <%= link_to organization.name, root_url(subdomain: organization.subdomain), class: "text-brand hover:underline font-medium" %>
         </li>
       <% end %>
     </ul>
   <% else %>
-    <p class="mt-8 text-gray-500">No community foundations have been set up yet.</p>
+    <p class="mt-8 text-ink-soft">No community foundations have been set up yet.</p>
   <% end %>
 </div>

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -1,21 +1,21 @@
 <div class="mx-auto max-w-xl w-full px-4 py-16 text-center">
   <% if authenticated? %>
-    <h1 class="font-bold text-4xl tracking-tight text-gray-900">
-      Hello, <span class="text-blue-600"><%= Current.user.email_address %></span>
+    <h1 class="font-serif font-medium text-4xl tracking-tight text-ink">
+      Hello, <span class="text-brand"><%= Current.user.email_address %></span>
     </h1>
-    <p class="mt-3 text-gray-500">You're signed in to <%= Current.organization.name %>.</p>
+    <p class="mt-3 text-ink-soft">You're signed in to <%= Current.organization.name %>.</p>
 
     <div class="mt-8 flex items-center justify-center gap-4">
-      <%= link_to "Explore options", scenarios_path, class: "rounded-md px-3.5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white font-medium inline-block" %>
-      <%= button_to "Sign out", session_path, method: :delete, class: "rounded-md px-3.5 py-2.5 border border-gray-400 hover:bg-gray-50 text-gray-700 font-medium cursor-pointer" %>
+      <%= link_to "Explore options", scenarios_path, class: "rounded-md px-3.5 py-2.5 bg-accent hover:bg-[#444] text-white font-medium inline-block transition" %>
+      <%= button_to "Sign out", session_path, method: :delete, class: "rounded-md px-3.5 py-2.5 border border-line bg-surface hover:bg-canvas text-ink-soft font-medium cursor-pointer transition" %>
     </div>
   <% else %>
-    <h1 class="font-bold text-4xl tracking-tight text-gray-900">Welcome to <%= Current.organization.name %></h1>
-    <p class="mt-3 text-gray-500">Sign in to your account or create a new one to get started.</p>
+    <h1 class="font-serif font-medium text-4xl tracking-tight text-ink">Welcome to <%= Current.organization.name %></h1>
+    <p class="mt-3 text-ink-soft">Sign in to your account or create a new one to get started.</p>
 
     <div class="mt-8 flex items-center justify-center gap-4">
-      <%= link_to "Sign in", new_session_path, class: "rounded-md px-3.5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white font-medium inline-block" %>
-      <%= link_to "Sign up", new_registration_path, class: "rounded-md px-3.5 py-2.5 border border-gray-400 hover:bg-gray-50 text-gray-700 font-medium inline-block" %>
+      <%= link_to "Sign in", new_session_path, class: "rounded-md px-3.5 py-2.5 bg-accent hover:bg-[#444] text-white font-medium inline-block transition" %>
+      <%= link_to "Sign up", new_registration_path, class: "rounded-md px-3.5 py-2.5 border border-line bg-surface hover:bg-canvas text-ink-soft font-medium inline-block transition" %>
     </div>
   <% end %>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,10 @@
     <%# Enable PWA manifest for installable apps (make sure to enable in config/routes.rb too!) %>
     <%#= tag.link rel: "manifest", href: pwa_manifest_path(format: :json) %>
 
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Lora:wght@400;500;600&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
+
     <link rel="icon" href="/icon.png" type="image/png">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
@@ -23,12 +27,17 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body>
-    <div class="container mx-auto mt-8 px-5">
+  <body class="min-h-screen bg-canvas">
+    <nav class="sticky top-0 z-50 flex h-13 items-center border-b border-line bg-surface px-6 sm:px-9">
+      <%= link_to (Current.organization&.name || "Community Foundations"), root_path,
+            class: "font-serif text-lg tracking-tight text-ink hover:text-ink" %>
+    </nav>
+
+    <div class="mx-auto w-full max-w-6xl px-5 pt-6">
       <%= render "shared/flash" %>
-      <main class="flex">
-        <%= yield %>
-      </main>
     </div>
+    <main>
+      <%= yield %>
+    </main>
   </body>
 </html>

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -1,17 +1,19 @@
-<div class="mx-auto md:w-2/3 w-full">
-  <h1 class="font-bold text-4xl">Update your password</h1>
+<div class="mx-auto max-w-md w-full px-4 py-16">
+  <div class="rounded-2xl border border-line bg-surface p-8 shadow-sm">
+    <h1 class="font-serif font-medium text-3xl tracking-tight text-ink">Update your password</h1>
 
-  <%= form_with url: password_path(params[:token]), method: :put, class: "contents" do |form| %>
-    <div class="my-5">
-      <%= form.password_field :password, required: true, autocomplete: "new-password", placeholder: "Enter new password", maxlength: 72, class: "block shadow-sm rounded-md border border-gray-400 focus:outline-solid focus:outline-blue-600 px-3 py-2 mt-2 w-full" %>
-    </div>
+    <%= form_with url: password_path(params[:token]), method: :put, class: "contents" do |form| %>
+      <div class="my-5">
+        <%= form.password_field :password, required: true, autocomplete: "new-password", placeholder: "Enter new password", maxlength: 72, class: "block shadow-sm rounded-md border border-line bg-surface px-3 py-2 mt-2 w-full focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
+      </div>
 
-    <div class="my-5">
-      <%= form.password_field :password_confirmation, required: true, autocomplete: "new-password", placeholder: "Repeat new password", maxlength: 72, class: "block shadow-sm rounded-md border border-gray-400 focus:outline-solid focus:outline-blue-600 px-3 py-2 mt-2 w-full" %>
-    </div>
+      <div class="my-5">
+        <%= form.password_field :password_confirmation, required: true, autocomplete: "new-password", placeholder: "Repeat new password", maxlength: 72, class: "block shadow-sm rounded-md border border-line bg-surface px-3 py-2 mt-2 w-full focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
+      </div>
 
-    <div class="inline">
-      <%= form.submit "Save", class: "w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white inline-block font-medium cursor-pointer" %>
-    </div>
-  <% end %>
+      <div class="inline">
+        <%= form.submit "Save", class: "w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 bg-accent hover:bg-[#444] text-white inline-block font-medium cursor-pointer transition" %>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -1,13 +1,15 @@
-<div class="mx-auto md:w-2/3 w-full">
-  <h1 class="font-bold text-4xl">Forgot your password?</h1>
+<div class="mx-auto max-w-md w-full px-4 py-16">
+  <div class="rounded-2xl border border-line bg-surface p-8 shadow-sm">
+    <h1 class="font-serif font-medium text-3xl tracking-tight text-ink">Forgot your password?</h1>
 
-  <%= form_with url: passwords_path, class: "contents" do |form| %>
-    <div class="my-5">
-      <%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email_address], class: "block shadow-sm rounded-md border border-gray-400 focus:outline-solid focus:outline-blue-600 px-3 py-2 mt-2 w-full" %>
-    </div>
+    <%= form_with url: passwords_path, class: "contents" do |form| %>
+      <div class="my-5">
+        <%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email_address], class: "block shadow-sm rounded-md border border-line bg-surface px-3 py-2 mt-2 w-full focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
+      </div>
 
-    <div class="inline">
-      <%= form.submit "Email reset instructions", class: "w-full sm:w-auto text-center rounded-lg px-3.5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white inline-block font-medium cursor-pointer" %>
-    </div>
-  <% end %>
+      <div class="inline">
+        <%= form.submit "Email reset instructions", class: "w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 bg-accent hover:bg-[#444] text-white inline-block font-medium cursor-pointer transition" %>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -1,43 +1,45 @@
-<div class="mx-auto md:w-2/3 w-full">
-  <h1 class="font-bold text-4xl">Sign up</h1>
+<div class="mx-auto max-w-md w-full px-4 py-16">
+  <div class="rounded-2xl border border-line bg-surface p-8 shadow-sm">
+    <h1 class="font-serif font-medium text-3xl tracking-tight text-ink">Sign up</h1>
 
-  <%= form_with model: @user, url: registration_url, class: "contents" do |form| %>
-    <% if @user.errors.any? %>
-      <div class="py-2 px-3 bg-red-50 mb-5 text-red-500 font-medium rounded-lg" id="error_explanation">
-        <ul class="list-disc list-inside">
-          <% @user.errors.full_messages.each do |message| %>
-            <li><%= message %></li>
-          <% end %>
-        </ul>
+    <%= form_with model: @user, url: registration_url, class: "contents" do |form| %>
+      <% if @user.errors.any? %>
+        <div class="mt-5 py-2 px-3 bg-danger-tint text-danger font-medium rounded-lg" id="error_explanation">
+          <ul class="list-disc list-inside">
+            <% @user.errors.full_messages.each do |message| %>
+              <li><%= message %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+      <%# Honeypot: hidden from real users, but bots tend to fill every field. Submissions with this set are silently dropped. %>
+      <div class="absolute left-[-9999px]" aria-hidden="true">
+        <%= label_tag :nickname, "Leave this field blank" %>
+        <%= text_field_tag :nickname, nil, tabindex: -1, autocomplete: "off" %>
+      </div>
+
+      <div class="my-5">
+        <%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", class: "block shadow-sm rounded-md border border-line bg-surface px-3 py-2 mt-2 w-full focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
+      </div>
+
+      <div class="my-5">
+        <%= form.password_field :password, required: true, autocomplete: "new-password", minlength: 8, placeholder: "Enter your password (min. 8 characters)", maxlength: 72, class: "block shadow-sm rounded-md border border-line bg-surface px-3 py-2 mt-2 w-full focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
+      </div>
+
+      <div class="my-5">
+        <%= form.password_field :password_confirmation, required: true, autocomplete: "new-password", placeholder: "Confirm your password", maxlength: 72, class: "block shadow-sm rounded-md border border-line bg-surface px-3 py-2 mt-2 w-full focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
+      </div>
+
+      <div class="mt-6 sm:flex sm:items-center sm:gap-4">
+        <div class="inline">
+          <%= form.submit "Sign up", class: "w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 bg-accent hover:bg-[#444] text-white inline-block font-medium cursor-pointer transition" %>
+        </div>
+
+        <div class="mt-4 text-sm text-ink-soft sm:mt-0">
+          <%= link_to "Already have an account? Sign in", new_session_path, class: "text-ink hover:text-brand underline" %>
+        </div>
       </div>
     <% end %>
-
-    <%# Honeypot: hidden from real users, but bots tend to fill every field. Submissions with this set are silently dropped. %>
-    <div class="absolute left-[-9999px]" aria-hidden="true">
-      <%= label_tag :nickname, "Leave this field blank" %>
-      <%= text_field_tag :nickname, nil, tabindex: -1, autocomplete: "off" %>
-    </div>
-
-    <div class="my-5">
-      <%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", class: "block shadow-sm rounded-md border border-gray-400 focus:outline-blue-600 px-3 py-2 mt-2 w-full" %>
-    </div>
-
-    <div class="my-5">
-      <%= form.password_field :password, required: true, autocomplete: "new-password", minlength: 8, placeholder: "Enter your password (min. 8 characters)", maxlength: 72, class: "block shadow-sm rounded-md border border-gray-400 focus:outline-blue-600 px-3 py-2 mt-2 w-full" %>
-    </div>
-
-    <div class="my-5">
-      <%= form.password_field :password_confirmation, required: true, autocomplete: "new-password", placeholder: "Confirm your password", maxlength: 72, class: "block shadow-sm rounded-md border border-gray-400 focus:outline-blue-600 px-3 py-2 mt-2 w-full" %>
-    </div>
-
-    <div class="col-span-6 sm:flex sm:items-center sm:gap-4">
-      <div class="inline">
-        <%= form.submit "Sign up", class: "w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white inline-block font-medium cursor-pointer" %>
-      </div>
-
-      <div class="mt-4 text-sm text-gray-500 sm:mt-0">
-        <%= link_to "Already have an account? Sign in", new_session_path, class: "text-gray-700 underline hover:no-underline" %>
-      </div>
-    </div>
-  <% end %>
+  </div>
 </div>

--- a/app/views/scenarios/_allocation.html.erb
+++ b/app/views/scenarios/_allocation.html.erb
@@ -1,16 +1,16 @@
-<div class="flex items-start justify-between gap-3 rounded-lg border border-gray-200 px-4 py-3">
+<div class="flex items-start justify-between gap-3 rounded-lg border border-line-soft bg-surface px-4 py-3 transition hover:shadow-sm">
   <div class="min-w-0">
-    <p class="font-medium text-gray-900 truncate"><%= allocation.option %></p>
+    <p class="font-medium text-ink truncate"><%= allocation.option %></p>
     <% if allocation.note.present? %>
-      <p class="mt-1 text-sm text-gray-500"><%= allocation.note %></p>
+      <p class="mt-1 text-sm text-ink-soft"><%= allocation.note %></p>
     <% end %>
   </div>
   <div class="flex items-center gap-3 shrink-0">
-    <span class="font-semibold text-gray-900">
+    <span class="font-semibold text-ink">
       <%= allocation.ongoing? ? "#{allocation.percentage}%" : number_to_currency(allocation.amount) %>
     </span>
     <%= button_to "✕", scenario_allocation_path(allocation.scenario, allocation), method: :delete,
-          class: "text-gray-400 hover:text-red-500 cursor-pointer bg-transparent p-0 leading-none",
+          class: "text-ink-faint hover:text-danger cursor-pointer bg-transparent p-0 leading-none",
           data: { turbo_confirm: "Remove this allocation?" } %>
   </div>
 </div>

--- a/app/views/scenarios/_allocation_modal.html.erb
+++ b/app/views/scenarios/_allocation_modal.html.erb
@@ -1,49 +1,49 @@
 <% suffix = klass.model_name.element %>
-<dialog data-dialog-target="dialog" class="m-auto w-full max-w-lg rounded-2xl p-0 backdrop:bg-black/30">
+<dialog data-dialog-target="dialog" class="m-auto w-full max-w-lg rounded-2xl p-0 shadow-lg backdrop:bg-[rgba(20,18,14,0.48)]">
   <%= form_with url: scenario_allocations_path(@scenario), class: "p-8" do |form| %>
     <%= hidden_field_tag "allocation[type]", klass.name %>
-    <h2 class="font-bold text-2xl text-gray-900">Create allocation</h2>
+    <h2 class="font-serif font-medium text-2xl text-ink">Create allocation</h2>
 
     <div class="mt-6">
-      <%= label_tag "allocation_option_#{suffix}", "Option", class: "block text-sm text-gray-600" %>
+      <%= label_tag "allocation_option_#{suffix}", "Option", class: "block text-sm text-ink-soft" %>
       <%= text_field_tag "allocation[option]", nil, id: "allocation_option_#{suffix}", required: true,
-            class: "mt-1 block w-full rounded-md border border-gray-400 focus:outline-blue-600 px-3 py-2 shadow-sm" %>
+            class: "mt-1 block w-full rounded-md border border-line bg-surface px-3 py-2 shadow-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
     </div>
 
     <% if klass == Allocation::Ongoing %>
       <div class="mt-6" data-controller="range">
         <div class="flex items-center justify-between">
-          <span class="text-sm text-gray-600">Giving percentage %</span>
-          <span class="text-sm text-gray-400">100 % reminder</span>
+          <span class="text-sm text-ink-soft">Giving percentage %</span>
+          <span class="text-sm text-ink-faint">100 % reminder</span>
         </div>
-        <p class="mt-1 text-lg font-medium text-gray-900"><span data-range-target="output">20</span> %</p>
+        <p class="mt-1 text-lg font-medium text-ink"><span data-range-target="output">20</span> %</p>
         <%= range_field_tag "allocation[percentage]", 20, min: 0, max: 100, step: 1,
               data: { range_target: "input", action: "input->range#update" },
-              class: "mt-2 w-full" %>
+              class: "mt-2 w-full accent-brand" %>
       </div>
     <% else %>
       <div class="mt-6">
-        <%= label_tag "allocation_amount_#{suffix}", "Amount", class: "block text-sm text-gray-600" %>
+        <%= label_tag "allocation_amount_#{suffix}", "Amount", class: "block text-sm text-ink-soft" %>
         <div class="relative mt-1">
-          <span class="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">$</span>
+          <span class="absolute left-3 top-1/2 -translate-y-1/2 text-ink-faint">$</span>
           <%= number_field_tag "allocation[amount]", nil, id: "allocation_amount_#{suffix}", min: 0, step: "0.01", required: true, placeholder: "0.00",
-                class: "block w-full rounded-md border border-gray-400 focus:outline-blue-600 pl-7 pr-3 py-2 shadow-sm" %>
+                class: "block w-full rounded-md border border-line bg-surface pl-7 pr-3 py-2 shadow-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
         </div>
       </div>
     <% end %>
 
     <div class="mt-6">
-      <%= label_tag "allocation_note_#{suffix}", "Note (optional)", class: "block text-sm text-gray-600" %>
+      <%= label_tag "allocation_note_#{suffix}", "Note (optional)", class: "block text-sm text-ink-soft" %>
       <%= text_area_tag "allocation[note]", nil, id: "allocation_note_#{suffix}", rows: 3, placeholder: "Extra preferences",
-            class: "mt-1 block w-full rounded-md border border-gray-400 focus:outline-blue-600 px-3 py-2 shadow-sm" %>
+            class: "mt-1 block w-full rounded-md border border-line bg-surface px-3 py-2 shadow-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
     </div>
 
     <div class="mt-8 flex justify-end gap-3">
       <button type="button" data-action="dialog#close"
-              class="rounded-md border border-gray-300 px-5 py-2.5 font-medium text-gray-700 hover:bg-gray-50 cursor-pointer">
+              class="rounded-md border border-line bg-surface px-5 py-2.5 font-medium text-ink-soft hover:bg-canvas cursor-pointer transition">
         Cancel
       </button>
-      <%= form.submit "Create", class: "rounded-md px-5 py-2.5 bg-gray-700 hover:bg-gray-600 text-white font-medium cursor-pointer" %>
+      <%= form.submit "Create", class: "rounded-md px-5 py-2.5 bg-accent hover:bg-[#444] text-white font-medium cursor-pointer transition" %>
     </div>
   <% end %>
 </dialog>

--- a/app/views/scenarios/_allocation_section.html.erb
+++ b/app/views/scenarios/_allocation_section.html.erb
@@ -1,10 +1,10 @@
 <div class="mt-6" data-controller="dialog">
   <div class="flex items-center justify-between">
-    <h3 class="font-semibold text-gray-900"><%= title %></h3>
+    <h3 class="text-[12px] font-semibold uppercase tracking-wide text-ink-soft"><%= title %></h3>
     <button type="button"
             data-action="dialog#open"
-            class="rounded-md px-3 py-1.5 text-sm font-medium bg-gray-700 hover:bg-gray-600 text-white cursor-pointer">
-      Add allocation
+            class="inline-flex items-center gap-1 rounded-md px-3 py-1.5 text-sm font-medium bg-accent hover:bg-[#444] text-white cursor-pointer transition">
+      + Add allocation
     </button>
   </div>
 
@@ -13,7 +13,7 @@
       <%= render partial: "allocation", collection: allocations %>
     </div>
   <% else %>
-    <div class="mt-3 rounded-lg border border-gray-200 bg-gray-50 py-12 text-center text-gray-500">
+    <div class="mt-3 rounded-xl border border-line-soft bg-surface-soft py-12 text-center text-ink-faint">
       Start to create allocation
     </div>
   <% end %>

--- a/app/views/scenarios/index.html.erb
+++ b/app/views/scenarios/index.html.erb
@@ -1,37 +1,37 @@
 <div class="mx-auto max-w-4xl w-full px-4 py-12">
   <div class="flex items-start justify-between gap-4">
     <div>
-      <h1 class="font-bold text-4xl tracking-tight text-gray-900">Explore options</h1>
-      <p class="mt-3 max-w-xl text-gray-500">
+      <h1 class="font-serif font-medium text-4xl tracking-tight text-ink">Explore options</h1>
+      <p class="mt-3 max-w-xl text-ink-soft">
         Explore different ways to allocate your giving. Create scenarios to see how your support could
         be distributed across programs, populations, and organizations.
       </p>
     </div>
     <%= link_to "Create scenario", new_scenario_path,
-          class: "shrink-0 rounded-md px-3.5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white font-medium inline-block" %>
+          class: "shrink-0 rounded-md px-3.5 py-2.5 bg-accent hover:bg-[#444] text-white font-medium inline-block transition" %>
   </div>
 
   <% if @scenarios.any? %>
     <div class="mt-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
       <% @scenarios.each do |scenario| %>
-        <div class="rounded-xl border border-gray-200 p-5 hover:shadow-sm transition">
+        <div class="rounded-2xl border border-line bg-surface p-5 shadow-sm hover:shadow-md transition">
           <div class="flex items-center justify-between">
-            <%= link_to scenario.name, scenario_path(scenario), class: "font-semibold text-lg text-gray-900 hover:text-blue-600" %>
+            <%= link_to scenario.name, scenario_path(scenario), class: "font-serif font-medium text-lg text-ink hover:text-brand" %>
           </div>
-          <p class="mt-2 text-gray-500">
+          <p class="mt-2 text-ink-soft">
             <%= scenario.total_giving_amount.present? ? number_to_currency(scenario.total_giving_amount) : "No total set" %>
           </p>
           <div class="mt-4 flex items-center gap-3 text-sm">
-            <%= link_to "Open", scenario_path(scenario), class: "text-blue-600 hover:underline" %>
+            <%= link_to "Open", scenario_path(scenario), class: "text-brand hover:underline" %>
             <%= button_to "Delete", scenario_path(scenario), method: :delete,
-                  class: "text-red-500 hover:underline cursor-pointer bg-transparent p-0",
+                  class: "text-danger hover:underline cursor-pointer bg-transparent p-0",
                   data: { turbo_confirm: "Delete this scenario?" } %>
           </div>
         </div>
       <% end %>
     </div>
   <% else %>
-    <div class="mt-10 rounded-xl border border-dashed border-gray-300 py-20 text-center text-gray-500">
+    <div class="mt-10 rounded-2xl border border-dashed border-line py-20 text-center text-ink-faint">
       No scenarios yet. Create one to start exploring.
     </div>
   <% end %>

--- a/app/views/scenarios/new.html.erb
+++ b/app/views/scenarios/new.html.erb
@@ -1,26 +1,26 @@
 <div class="mx-auto max-w-xl w-full px-4 py-12">
   <%= link_to "← Back to explore options", scenarios_path,
-        class: "inline-block rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50" %>
+        class: "inline-block rounded-md border border-line bg-surface px-3 py-1.5 text-sm text-ink-soft hover:bg-canvas transition" %>
 
-  <h1 class="mt-6 font-bold text-3xl tracking-tight text-gray-900">New scenario</h1>
-  <p class="mt-2 text-gray-500">Give your scenario a name to get started. You'll set the giving amount and add allocations next.</p>
+  <h1 class="mt-6 font-serif font-medium text-3xl tracking-tight text-ink">New scenario</h1>
+  <p class="mt-2 text-ink-soft">Give your scenario a name to get started. You'll set the giving amount and add allocations next.</p>
 
   <%= form_with model: @scenario, class: "contents" do |form| %>
     <% if @scenario.errors.any? %>
-      <p class="mt-5 py-2 px-3 bg-red-50 text-red-500 font-medium rounded-lg inline-block">
+      <p class="mt-5 py-2 px-3 bg-danger-tint text-danger font-medium rounded-lg inline-block">
         <%= @scenario.errors.full_messages.to_sentence %>
       </p>
     <% end %>
 
     <div class="mt-6">
-      <%= form.label :name, class: "block text-gray-600" %>
+      <%= form.label :name, class: "block text-ink-soft" %>
       <%= form.text_field :name, required: true, autofocus: true, placeholder: "e.g. Education focus",
-            class: "mt-2 block w-full rounded-md border border-gray-400 focus:outline-blue-600 px-3 py-2 shadow-sm" %>
+            class: "mt-2 block w-full rounded-md border border-line bg-surface px-3 py-2 shadow-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
     </div>
 
     <div class="mt-6 flex items-center gap-3">
-      <%= form.submit "Create scenario", class: "rounded-md px-3.5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white font-medium cursor-pointer" %>
-      <%= link_to "Cancel", scenarios_path, class: "text-gray-600 hover:underline" %>
+      <%= form.submit "Create scenario", class: "rounded-md px-3.5 py-2.5 bg-accent hover:bg-[#444] text-white font-medium cursor-pointer transition" %>
+      <%= link_to "Cancel", scenarios_path, class: "text-ink-soft hover:underline" %>
     </div>
   <% end %>
 </div>

--- a/app/views/scenarios/show.html.erb
+++ b/app/views/scenarios/show.html.erb
@@ -1,35 +1,35 @@
 <div class="mx-auto max-w-5xl w-full px-4 py-10">
   <%= link_to "← Back to explore options", scenarios_path,
-        class: "inline-block rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50" %>
+        class: "inline-block rounded-md border border-line bg-surface px-3 py-1.5 text-sm text-ink-soft hover:bg-canvas transition" %>
 
-  <h1 class="mt-6 font-bold text-3xl tracking-tight text-gray-900"><%= @scenario.name %></h1>
+  <h1 class="mt-6 font-serif font-medium text-3xl tracking-tight text-ink"><%= @scenario.name %></h1>
 
   <%= form_with model: @scenario, class: "contents" do |form| %>
     <div class="mt-6 flex items-center gap-4">
-      <%= form.label :name, class: "w-40 text-gray-600" %>
+      <%= form.label :name, class: "w-40 text-ink-soft" %>
       <%= form.text_field :name, required: true,
-            class: "max-w-md w-full block rounded-md border border-gray-400 focus:outline-blue-600 px-3 py-2 shadow-sm" %>
+            class: "max-w-md w-full block rounded-md border border-line bg-surface px-3 py-2 shadow-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
     </div>
 
     <div class="mt-4 flex items-center gap-4">
-      <%= form.label :total_giving_amount, "Total giving amount", class: "w-40 text-gray-600" %>
+      <%= form.label :total_giving_amount, "Total giving amount", class: "w-40 text-ink-soft" %>
       <div class="relative max-w-md w-full">
-        <span class="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">$</span>
+        <span class="absolute left-3 top-1/2 -translate-y-1/2 text-ink-faint">$</span>
         <%= form.number_field :total_giving_amount, step: "0.01", min: 0, placeholder: "0.00",
-              class: "block w-full rounded-md border border-gray-400 focus:outline-blue-600 pl-7 pr-3 py-2 shadow-sm" %>
+              class: "block w-full rounded-md border border-line bg-surface pl-7 pr-3 py-2 shadow-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
       </div>
     </div>
 
     <div class="mt-4 flex items-center gap-4">
       <span class="w-40"></span>
-      <%= form.submit "Save", class: "rounded-md px-3 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium cursor-pointer" %>
+      <%= form.submit "Save", class: "rounded-md px-3.5 py-2 bg-accent hover:bg-[#444] text-white text-sm font-medium cursor-pointer transition" %>
     </div>
   <% end %>
 
   <div class="mt-8 grid gap-6 lg:grid-cols-2">
     <!-- Allocations -->
-    <div class="rounded-xl border border-gray-200 p-6">
-      <h2 class="font-bold text-xl text-gray-900">Allocations</h2>
+    <div class="rounded-2xl border border-line bg-surface p-6 shadow-sm">
+      <h2 class="font-serif font-medium text-xl text-ink">Allocations</h2>
 
       <%= render "allocation_section",
             title: "On going giving",
@@ -43,42 +43,42 @@
     </div>
 
     <!-- Summary -->
-    <div class="rounded-xl border border-gray-200 p-6">
-      <h2 class="font-bold text-xl text-gray-900">Allocation summary</h2>
+    <div class="rounded-2xl border border-line bg-surface p-6 shadow-sm">
+      <h2 class="font-serif font-medium text-xl text-ink">Allocation summary</h2>
 
       <div class="mt-5">
-        <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500">On going giving</h3>
+        <h3 class="text-[11px] font-semibold uppercase tracking-wide text-ink-faint">On going giving</h3>
         <% if @scenario.ongoing_allocations.any? %>
           <ul class="mt-3 space-y-2">
             <% @scenario.ongoing_allocations.each do |allocation| %>
-              <li class="flex justify-between text-gray-700">
+              <li class="flex justify-between text-ink-soft">
                 <span><%= allocation.option %></span>
-                <span class="font-medium"><%= allocation.percentage %>%</span>
+                <span class="font-medium text-ink"><%= allocation.percentage %>%</span>
               </li>
             <% end %>
           </ul>
           <% total = @scenario.ongoing_percentage_total %>
-          <p class="mt-3 text-sm font-medium <%= total == 100 ? "text-green-600" : "text-gray-500" %>">
+          <p class="mt-3 text-sm font-medium <%= total == 100 ? "text-success" : "text-ink-faint" %>">
             <%= total %>% of 100%<%= " — add #{100 - total}% more" if total < 100 %><%= " — #{total - 100}% over" if total > 100 %>
           </p>
         <% else %>
-          <p class="mt-3 text-gray-400">No ongoing allocations yet.</p>
+          <p class="mt-3 text-ink-faint">No ongoing allocations yet.</p>
         <% end %>
       </div>
 
       <div class="mt-6">
-        <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500">One time giving</h3>
+        <h3 class="text-[11px] font-semibold uppercase tracking-wide text-ink-faint">One time giving</h3>
         <% if @scenario.one_time_allocations.any? %>
           <ul class="mt-3 space-y-2">
             <% @scenario.one_time_allocations.each do |allocation| %>
-              <li class="flex justify-between text-gray-700">
+              <li class="flex justify-between text-ink-soft">
                 <span><%= allocation.option %></span>
-                <span class="font-medium"><%= number_to_currency(allocation.amount) %></span>
+                <span class="font-medium text-ink"><%= number_to_currency(allocation.amount) %></span>
               </li>
             <% end %>
           </ul>
         <% else %>
-          <p class="mt-3 text-gray-400">No one-time allocations yet.</p>
+          <p class="mt-3 text-ink-faint">No one-time allocations yet.</p>
         <% end %>
       </div>
     </div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,25 +1,27 @@
-<div class="mx-auto md:w-2/3 w-full">
-  <h1 class="font-bold text-4xl">Sign in</h1>
+<div class="mx-auto max-w-md w-full px-4 py-16">
+  <div class="rounded-2xl border border-line bg-surface p-8 shadow-sm">
+    <h1 class="font-serif font-medium text-3xl tracking-tight text-ink">Sign in</h1>
 
-  <%= form_with url: session_url, class: "contents" do |form| %>
-    <div class="my-5">
-      <%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email_address], class: "block shadow-sm rounded-md border border-gray-400 focus:outline-blue-600 px-3 py-2 mt-2 w-full" %>
-    </div>
-
-    <div class="my-5">
-      <%= form.password_field :password, required: true, autocomplete: "current-password", placeholder: "Enter your password", maxlength: 72, class: "block shadow-sm rounded-md border border-gray-400 focus:outline-blue-600 px-3 py-2 mt-2 w-full" %>
-    </div>
-
-    <div class="col-span-6 sm:flex sm:items-center sm:gap-4">
-      <div class="inline">
-        <%= form.submit "Sign in", class: "w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white inline-block font-medium cursor-pointer" %>
+    <%= form_with url: session_url, class: "contents" do |form| %>
+      <div class="my-5">
+        <%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email_address], class: "block shadow-sm rounded-md border border-line bg-surface px-3 py-2 mt-2 w-full focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
       </div>
 
-      <div class="mt-4 text-sm text-gray-500 sm:mt-0">
-        <%= link_to "Sign up", new_registration_path, class: "text-gray-700 underline hover:no-underline" %>
-        &middot;
-        <%= link_to "Forgot password?", new_password_path, class: "text-gray-700 underline hover:no-underline" %>
+      <div class="my-5">
+        <%= form.password_field :password, required: true, autocomplete: "current-password", placeholder: "Enter your password", maxlength: 72, class: "block shadow-sm rounded-md border border-line bg-surface px-3 py-2 mt-2 w-full focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
       </div>
-    </div>
-  <% end %>
+
+      <div class="mt-6 sm:flex sm:items-center sm:gap-4">
+        <div class="inline">
+          <%= form.submit "Sign in", class: "w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 bg-accent hover:bg-[#444] text-white inline-block font-medium cursor-pointer transition" %>
+        </div>
+
+        <div class="mt-4 text-sm text-ink-soft sm:mt-0">
+          <%= link_to "Sign up", new_registration_path, class: "text-ink hover:text-brand underline" %>
+          &middot;
+          <%= link_to "Forgot password?", new_password_path, class: "text-ink hover:text-brand underline" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,6 +1,6 @@
 <% flash.each do |type, message| %>
   <% next if message.blank? %>
-  <p id="<%= type %>" class="mb-5 py-2 px-3 font-medium rounded-lg inline-block <%= type.to_s == "alert" ? "bg-red-50 text-red-500" : "bg-green-50 text-green-600" %>">
+  <p id="<%= type %>" class="mb-5 py-2 px-3 font-medium rounded-lg inline-block <%= type.to_s == "alert" ? "bg-danger-tint text-danger" : "bg-success-tint text-success" %>">
     <%= message %>
   </p>
 <% end %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -31,6 +31,13 @@ if balanced.allocations.empty?
   balanced.one_time_allocations.create!(option: "Specific org", amount: 1_000)
 end
 
-user.scenarios.find_or_create_by!(organization: arlington, name: "Education focus") do |scenario|
+education = user.scenarios.find_or_create_by!(organization: arlington, name: "Education focus") do |scenario|
   scenario.total_giving_amount = 5_000
+end
+
+if education.allocations.empty?
+  education.ongoing_allocations.create!(option: "Program: Education", percentage: 60)
+  education.ongoing_allocations.create!(option: "Population: Youth (5–21)", percentage: 25)
+  education.ongoing_allocations.create!(option: "Greatest Community Need", percentage: 15)
+  education.one_time_allocations.create!(option: "Scholarship Fund", amount: 500)
 end


### PR DESCRIPTION
Restyles the entire app to match the giving-allocations design mockup — a warm, editorial look — without adding any features. Introduces a Tailwind v4 `@theme` palette (cream canvas, charcoal accents, warm-orange brand), loads Lora + DM Sans, and adds a branded sticky top bar showing the foundation name. Every page (scenarios index/new/show and allocation partials/modal, home, sign in/up, password reset, and flash) now uses surface cards with soft shadows, serif headings, and the new color tokens. Also seeds ongoing and one-time allocations for the "Education focus" scenario. Stimulus controllers, routes, models, and controllers are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)