### PR TITLE
Make allocations editable

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -10,6 +10,15 @@ class AllocationsController < ApplicationController
     end
   end
 
+  def update
+    allocation = @scenario.allocations.find(params[:id])
+    if allocation.update(allocation_params)
+      redirect_to scenario_path(@scenario)
+    else
+      redirect_to scenario_path(@scenario), alert: allocation.errors.full_messages.to_sentence
+    end
+  end
+
   def destroy
     @scenario.allocations.find(params[:id]).destroy
     redirect_to scenario_path(@scenario)

--- a/app/views/scenarios/_allocation.html.erb
+++ b/app/views/scenarios/_allocation.html.erb
@@ -1,16 +1,24 @@
-<div class="flex items-start justify-between gap-3 rounded-lg border border-line-soft bg-surface px-4 py-3 transition hover:shadow-sm">
-  <div class="min-w-0">
-    <p class="font-medium text-ink truncate"><%= allocation.option %></p>
-    <% if allocation.note.present? %>
-      <p class="mt-1 text-sm text-ink-soft"><%= allocation.note %></p>
-    <% end %>
+<div data-controller="dialog">
+  <div class="flex items-start justify-between gap-3 rounded-lg border border-line-soft bg-surface px-4 py-3 transition hover:shadow-sm">
+    <div class="min-w-0">
+      <p class="font-medium text-ink truncate"><%= allocation.option %></p>
+      <% if allocation.note.present? %>
+        <p class="mt-1 text-sm text-ink-soft"><%= allocation.note %></p>
+      <% end %>
+    </div>
+    <div class="flex items-center gap-3 shrink-0">
+      <span class="font-semibold text-ink">
+        <%= allocation.ongoing? ? "#{allocation.percentage}%" : number_to_currency(allocation.amount) %>
+      </span>
+      <button type="button" data-action="dialog#open"
+              class="text-sm text-ink-faint hover:text-accent cursor-pointer bg-transparent p-0 leading-none">
+        Edit
+      </button>
+      <%= button_to "✕", scenario_allocation_path(allocation.scenario, allocation), method: :delete,
+            class: "text-ink-faint hover:text-danger cursor-pointer bg-transparent p-0 leading-none",
+            data: { turbo_confirm: "Remove this allocation?" } %>
+    </div>
   </div>
-  <div class="flex items-center gap-3 shrink-0">
-    <span class="font-semibold text-ink">
-      <%= allocation.ongoing? ? "#{allocation.percentage}%" : number_to_currency(allocation.amount) %>
-    </span>
-    <%= button_to "✕", scenario_allocation_path(allocation.scenario, allocation), method: :delete,
-          class: "text-ink-faint hover:text-danger cursor-pointer bg-transparent p-0 leading-none",
-          data: { turbo_confirm: "Remove this allocation?" } %>
-  </div>
+
+  <%= render "allocation_modal", allocation: allocation %>
 </div>

--- a/app/views/scenarios/_allocation_modal.html.erb
+++ b/app/views/scenarios/_allocation_modal.html.erb
@@ -1,12 +1,15 @@
-<% suffix = klass.model_name.element %>
+<% klass = allocation.class %>
+<% editing = allocation.persisted? %>
+<% suffix = editing ? dom_id(allocation) : klass.model_name.element %>
+<% percentage = allocation.percentage || 20 %>
 <dialog data-dialog-target="dialog" class="m-auto w-full max-w-lg rounded-2xl p-0 shadow-lg backdrop:bg-[rgba(20,18,14,0.48)]">
-  <%= form_with url: scenario_allocations_path(@scenario), class: "p-8" do |form| %>
+  <%= form_with url: (editing ? scenario_allocation_path(@scenario, allocation) : scenario_allocations_path(@scenario)), method: (editing ? :patch : :post), class: "p-8" do |form| %>
     <%= hidden_field_tag "allocation[type]", klass.name %>
-    <h2 class="font-serif font-medium text-2xl text-ink">Create allocation</h2>
+    <h2 class="font-serif font-medium text-2xl text-ink"><%= editing ? "Edit allocation" : "Create allocation" %></h2>
 
     <div class="mt-6">
       <%= label_tag "allocation_option_#{suffix}", "Option", class: "block text-sm text-ink-soft" %>
-      <%= text_field_tag "allocation[option]", nil, id: "allocation_option_#{suffix}", required: true,
+      <%= text_field_tag "allocation[option]", allocation.option, id: "allocation_option_#{suffix}", required: true,
             class: "mt-1 block w-full rounded-md border border-line bg-surface px-3 py-2 shadow-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
     </div>
 
@@ -16,8 +19,8 @@
           <span class="text-sm text-ink-soft">Giving percentage %</span>
           <span class="text-sm text-ink-faint">100 % reminder</span>
         </div>
-        <p class="mt-1 text-lg font-medium text-ink"><span data-range-target="output">20</span> %</p>
-        <%= range_field_tag "allocation[percentage]", 20, min: 0, max: 100, step: 1,
+        <p class="mt-1 text-lg font-medium text-ink"><span data-range-target="output"><%= percentage %></span> %</p>
+        <%= range_field_tag "allocation[percentage]", percentage, min: 0, max: 100, step: 1,
               data: { range_target: "input", action: "input->range#update" },
               class: "mt-2 w-full accent-brand" %>
       </div>
@@ -26,7 +29,7 @@
         <%= label_tag "allocation_amount_#{suffix}", "Amount", class: "block text-sm text-ink-soft" %>
         <div class="relative mt-1">
           <span class="absolute left-3 top-1/2 -translate-y-1/2 text-ink-faint">$</span>
-          <%= number_field_tag "allocation[amount]", nil, id: "allocation_amount_#{suffix}", min: 0, step: "0.01", required: true, placeholder: "0.00",
+          <%= number_field_tag "allocation[amount]", allocation.amount, id: "allocation_amount_#{suffix}", min: 0, step: "0.01", required: true, placeholder: "0.00",
                 class: "block w-full rounded-md border border-line bg-surface pl-7 pr-3 py-2 shadow-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
         </div>
       </div>
@@ -34,7 +37,7 @@
 
     <div class="mt-6">
       <%= label_tag "allocation_note_#{suffix}", "Note (optional)", class: "block text-sm text-ink-soft" %>
-      <%= text_area_tag "allocation[note]", nil, id: "allocation_note_#{suffix}", rows: 3, placeholder: "Extra preferences",
+      <%= text_area_tag "allocation[note]", allocation.note, id: "allocation_note_#{suffix}", rows: 3, placeholder: "Extra preferences, restrictions, e.g. need-based scholarships only, exclude specific orgs…",
             class: "mt-1 block w-full rounded-md border border-line bg-surface px-3 py-2 shadow-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
     </div>
 
@@ -43,7 +46,7 @@
               class="rounded-md border border-line bg-surface px-5 py-2.5 font-medium text-ink-soft hover:bg-canvas cursor-pointer transition">
         Cancel
       </button>
-      <%= form.submit "Create", class: "rounded-md px-5 py-2.5 bg-accent hover:bg-[#444] text-white font-medium cursor-pointer transition" %>
+      <%= form.submit (editing ? "Save" : "Create"), class: "rounded-md px-5 py-2.5 bg-accent hover:bg-[#444] text-white font-medium cursor-pointer transition" %>
     </div>
   <% end %>
 </dialog>

--- a/app/views/scenarios/_allocation_section.html.erb
+++ b/app/views/scenarios/_allocation_section.html.erb
@@ -18,5 +18,5 @@
     </div>
   <% end %>
 
-  <%= render "allocation_modal", klass: klass %>
+  <%= render "allocation_modal", allocation: klass.new %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   resource :session
 
   resources :scenarios do
-    resources :allocations, only: %i[ create destroy ]
+    resources :allocations, only: %i[ create update destroy ]
   end
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/test/controllers/allocations_controller_test.rb
+++ b/test/controllers/allocations_controller_test.rb
@@ -36,6 +36,47 @@ class AllocationsControllerTest < ActionDispatch::IntegrationTest
     assert flash[:alert].present?
   end
 
+  test "updates an ongoing allocation" do
+    allocation = allocations(:greatest_need)
+    patch scenario_allocation_url(@scenario, allocation), params: {
+      allocation: { option: "Greatest Need (revised)", percentage: 55, note: "Updated" }
+    }
+    assert_redirected_to scenario_path(@scenario)
+    allocation.reload
+    assert_equal "Greatest Need (revised)", allocation.option
+    assert_equal 55, allocation.percentage
+    assert_equal "Updated", allocation.note
+  end
+
+  test "updates a one time allocation" do
+    allocation = allocations(:education_grant)
+    patch scenario_allocation_url(@scenario, allocation), params: {
+      allocation: { amount: 4000 }
+    }
+    assert_redirected_to scenario_path(@scenario)
+    assert_equal 4000, allocation.reload.amount
+  end
+
+  test "rejects an update that exceeds the total giving amount" do
+    # scenario total is 10000; education_grant is the only one_time allocation.
+    allocation = allocations(:education_grant)
+    patch scenario_allocation_url(@scenario, allocation), params: {
+      allocation: { amount: 11000 }
+    }
+    assert_redirected_to scenario_path(@scenario)
+    assert flash[:alert].present?
+    assert_equal 5000, allocation.reload.amount
+  end
+
+  test "cannot update an allocation on a scenario you do not own" do
+    # set_scenario scopes to the current user, so the unowned scenario 404s
+    # before the allocation is ever looked up.
+    patch scenario_allocation_url(scenarios(:two_boston), allocations(:greatest_need)), params: {
+      allocation: { option: "Hacked" }
+    }
+    assert_response :not_found
+  end
+
   test "destroys an allocation" do
     assert_difference -> { @scenario.allocations.count }, -1 do
       delete scenario_allocation_url(@scenario, allocations(:greatest_need))


### PR DESCRIPTION
Allocations within a scenario could previously only be created and deleted, forcing users to delete and re-create an allocation to fix a typo or adjust a value. This PR adds an `update` action and a per-allocation edit modal so the option, percentage/amount, and note can be revised in place. The create and edit flows now share a single modal partial driven by the allocation record, keeping the existing Hotwire/dialog pattern. The note placeholder was also expanded to a clearer example. Controller tests cover updating both allocation types, the over-total validation, and ownership scoping.