### PR TITLE
Float flash messages as dismissible toasts

### DIFF
--- a/app/javascript/controllers/toast_controller.js
+++ b/app/javascript/controllers/toast_controller.js
@@ -1,0 +1,28 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Floating flash toast: fades in on connect, auto-dismisses after delayValue ms,
+// and can be dismissed early via data-action="toast#close".
+export default class extends Controller {
+  static values = { delay: { type: Number, default: 5000 } }
+
+  connect() {
+    // Animate in on the next frame so the initial hidden classes apply first.
+    requestAnimationFrame(() => {
+      this.element.classList.remove("opacity-0", "translate-x-2")
+    })
+
+    if (this.delayValue > 0) {
+      this.timeout = setTimeout(() => this.close(), this.delayValue)
+    }
+  }
+
+  close() {
+    clearTimeout(this.timeout)
+    this.element.classList.add("opacity-0", "translate-x-2")
+    this.element.addEventListener("transitionend", () => this.element.remove(), { once: true })
+  }
+
+  disconnect() {
+    clearTimeout(this.timeout)
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,9 +33,8 @@
             class: "font-serif text-lg tracking-tight text-ink hover:text-ink" %>
     </nav>
 
-    <div class="mx-auto w-full max-w-6xl px-5 pt-6">
-      <%= render "shared/flash" %>
-    </div>
+    <%= render "shared/flash" %>
+
     <main>
       <%= yield %>
     </main>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,6 +1,16 @@
-<% flash.each do |type, message| %>
-  <% next if message.blank? %>
-  <p id="<%= type %>" class="mb-5 py-2 px-3 font-medium rounded-lg inline-block <%= type.to_s == "alert" ? "bg-danger-tint text-danger" : "bg-success-tint text-success" %>">
-    <%= message %>
-  </p>
-<% end %>
+<div class="fixed top-16 right-4 z-40 flex w-full max-w-sm flex-col gap-2 sm:right-6">
+  <% flash.each do |type, message| %>
+    <% next if message.blank? %>
+    <% alert = type.to_s == "alert" %>
+    <div id="<%= type %>"
+         data-controller="toast"
+         class="flex translate-x-2 items-start gap-3 rounded-lg border-l-4 bg-surface px-4 py-3 opacity-0 shadow-lg transition duration-300 ease-out <%= alert ? "border-danger" : "border-success" %>">
+      <span class="mt-1.5 h-2 w-2 shrink-0 rounded-full <%= alert ? "bg-danger" : "bg-success" %>" aria-hidden="true"></span>
+      <p class="flex-1 text-sm font-medium text-ink"><%= message %></p>
+      <button type="button"
+              data-action="toast#close"
+              aria-label="Dismiss"
+              class="-mr-1 shrink-0 text-lg leading-none text-ink-faint hover:text-ink">&times;</button>
+    </div>
+  <% end %>
+</div>


### PR DESCRIPTION
Flash messages rendered inline at the top of the page content, pushing the page down when shown, and the faint danger tint was nearly invisible against the canvas background. They now render as a fixed top-right toast stack that overlays content, using a white card with a solid colored left border and status dot for contrast plus a dismiss button. A new Stimulus `toast` controller fades each toast in and auto-dismisses it after 5s (manual close supported). The flash `id` values (`alert`/`notice`) are preserved so existing tests still match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)