### PR TITLE
Store giving amounts as integers (whole dollars)

### DIFF
--- a/app/models/allocation/one_time.rb
+++ b/app/models/allocation/one_time.rb
@@ -1,7 +1,7 @@
 class Allocation::OneTime < Allocation
   validates :amount,
     presence: true,
-    numericality: { greater_than: 0 }
+    numericality: { only_integer: true, greater_than: 0 }
   validate :within_total_giving_amount
 
   def ongoing?

--- a/app/views/scenarios/_allocation.html.erb
+++ b/app/views/scenarios/_allocation.html.erb
@@ -8,7 +8,7 @@
     </div>
     <div class="flex items-center gap-3 shrink-0">
       <span class="font-semibold text-ink">
-        <%= allocation.ongoing? ? "#{allocation.percentage}%" : number_to_currency(allocation.amount) %>
+        <%= allocation.ongoing? ? "#{allocation.percentage}%" : number_to_currency(allocation.amount, precision: 0) %>
       </span>
       <button type="button" data-action="dialog#open"
               class="text-sm text-ink-faint hover:text-accent cursor-pointer bg-transparent p-0 leading-none">

--- a/app/views/scenarios/_allocation_modal.html.erb
+++ b/app/views/scenarios/_allocation_modal.html.erb
@@ -29,7 +29,7 @@
         <%= label_tag "allocation_amount_#{suffix}", "Amount", class: "block text-sm text-ink-soft" %>
         <div class="relative mt-1">
           <span class="absolute left-3 top-1/2 -translate-y-1/2 text-ink-faint">$</span>
-          <%= number_field_tag "allocation[amount]", allocation.amount, id: "allocation_amount_#{suffix}", min: 0, step: "0.01", required: true, placeholder: "0.00",
+          <%= number_field_tag "allocation[amount]", allocation.amount, id: "allocation_amount_#{suffix}", min: 0, step: "1", required: true, placeholder: "0",
                 class: "block w-full rounded-md border border-line bg-surface pl-7 pr-3 py-2 shadow-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
         </div>
       </div>

--- a/app/views/scenarios/index.html.erb
+++ b/app/views/scenarios/index.html.erb
@@ -19,7 +19,7 @@
             <%= link_to scenario.name, scenario_path(scenario), class: "font-serif font-medium text-lg text-ink hover:text-brand" %>
           </div>
           <p class="mt-2 text-ink-soft">
-            <%= scenario.total_giving_amount.present? ? number_to_currency(scenario.total_giving_amount) : "No total set" %>
+            <%= scenario.total_giving_amount.present? ? number_to_currency(scenario.total_giving_amount, precision: 0) : "No total set" %>
           </p>
           <div class="mt-4 flex items-center gap-3 text-sm">
             <%= link_to "Open", scenario_path(scenario), class: "text-brand hover:underline" %>

--- a/app/views/scenarios/show.html.erb
+++ b/app/views/scenarios/show.html.erb
@@ -15,7 +15,7 @@
       <%= form.label :total_giving_amount, "Total giving amount", class: "w-40 text-ink-soft" %>
       <div class="relative max-w-md w-full">
         <span class="absolute left-3 top-1/2 -translate-y-1/2 text-ink-faint">$</span>
-        <%= form.number_field :total_giving_amount, step: "0.01", min: 0, placeholder: "0.00",
+        <%= form.number_field :total_giving_amount, step: "1", min: 0, placeholder: "0",
               class: "block w-full rounded-md border border-line bg-surface pl-7 pr-3 py-2 shadow-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
       </div>
     </div>
@@ -73,7 +73,7 @@
             <% @scenario.one_time_allocations.each do |allocation| %>
               <li class="flex justify-between text-ink-soft">
                 <span><%= allocation.option %></span>
-                <span class="font-medium text-ink"><%= number_to_currency(allocation.amount) %></span>
+                <span class="font-medium text-ink"><%= number_to_currency(allocation.amount, precision: 0) %></span>
               </li>
             <% end %>
           </ul>

--- a/db/migrate/20260611120000_change_amounts_to_integer.rb
+++ b/db/migrate/20260611120000_change_amounts_to_integer.rb
@@ -1,0 +1,6 @@
+class ChangeAmountsToInteger < ActiveRecord::Migration[8.1]
+  def change
+    change_column :scenarios, :total_giving_amount, :integer
+    change_column :allocations, :amount, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_10_120001) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_11_120000) do
   create_table "allocations", force: :cascade do |t|
     t.integer "scenario_id", null: false
     t.string "type", null: false
     t.string "option", null: false
     t.integer "percentage"
-    t.decimal "amount", precision: 12, scale: 2
+    t.integer "amount"
     t.text "note"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -46,7 +46,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_10_120001) do
     t.integer "organization_id", null: false
     t.integer "user_id", null: false
     t.string "name", null: false
-    t.decimal "total_giving_amount", precision: 12, scale: 2
+    t.integer "total_giving_amount"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["organization_id"], name: "index_scenarios_on_organization_id"


### PR DESCRIPTION
The app only deals with large, whole-dollar giving amounts, so this models `scenarios.total_giving_amount` and `allocations.amount` as integers instead of `decimal(12,2)` via a new migration. The `Allocation::OneTime` amount validation now requires `only_integer`, the amount form inputs step by 1 with `"0"` placeholders, and currency renders with `precision: 0` so values show as `$1,000` rather than `$1,000.00`. Seeds, fixtures, and existing tests already used whole numbers and pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)