### PR TITLE
Configure Kamal deployment to Hetzner server

### DIFF
--- a/.kamal/secrets
+++ b/.kamal/secrets
@@ -18,3 +18,7 @@
 
 # Improve security by using a password manager. Never check config/master.key into git!
 RAILS_MASTER_KEY=$(cat config/master.key)
+
+# GHCR personal access token (write:packages/read:packages). Read from 1Password
+# on the laptop; falls back to the env var if `op` is unavailable.
+KAMAL_REGISTRY_PASSWORD=$(op read "op://Personal/GitHub/GHCR_TOKEN" 2>/dev/null || printenv KAMAL_REGISTRY_PASSWORD)

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -2,12 +2,12 @@
 service: community_foundations
 
 # Name of the container image (use your-user/app-name on external registries).
-image: community_foundations
+image: kcdragon/community-foundations
 
 # Deploy to these servers.
 servers:
   web:
-    - 192.168.0.1
+    - 5.78.199.12
   # job:
   #   hosts:
   #     - 192.168.0.1
@@ -20,21 +20,21 @@ servers:
 #
 # Don't use this when deploying to multiple web servers (then you have to terminate SSL at your load balancer).
 #
-# proxy:
-#   ssl: true
-#   host: app.example.com
+proxy:
+  ssl: true
+  host: community-foundations.rowhomelabs.com
 
 # Where you keep your container images.
 registry:
   # Alternatives: hub.docker.com / registry.digitalocean.com / ghcr.io / ...
-  server: localhost:5555
+  server: ghcr.io
 
   # Needed for authenticated registries.
-  # username: your-user
+  username: kcdragon
 
   # Always use an access token rather than real password when possible.
-  # password:
-  #   - KAMAL_REGISTRY_PASSWORD
+  password:
+    - KAMAL_REGISTRY_PASSWORD
 
 # Inject ENV variables into containers (secrets come from .kamal/secrets).
 env:
@@ -66,10 +66,13 @@ aliases:
   logs: app logs -f
   dbc: app exec --interactive --reuse "bin/rails dbconsole --include-password"
 
-# Use a persistent storage volume for sqlite database files and local Active Storage files.
-# Recommended to change this to a mounted volume path that is backed up off server.
+# Persist sqlite database files and local Active Storage files on the block
+# volume (ID 105990510), mounted on the server at /mnt/HC_Volume_105990510.
+# The subdirectory must be owned by the container's rails user (uid/gid 1000):
+#   mkdir -p /mnt/HC_Volume_105990510/community_foundations_storage
+#   chown -R 1000:1000 /mnt/HC_Volume_105990510/community_foundations_storage
 volumes:
-  - "community_foundations_storage:/rails/storage"
+  - "/mnt/HC_Volume_105990510/community_foundations_storage:/rails/storage"
 
 # Bridge fingerprinted assets, like JS and CSS, between versions to avoid
 # hitting 404 on in-flight requests. Combines all files from new and old

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,10 +25,10 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
-  # config.assume_ssl = true
+  config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Skip http-to-https redirect for the default health check endpoint.
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
@@ -58,7 +58,7 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "example.com" }
+  config.action_mailer.default_url_options = { host: "community-foundations.rowhomelabs.com" }
 
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via bin/rails credentials:edit.
   # config.action_mailer.smtp_settings = {


### PR DESCRIPTION
Configures the stock Kamal scaffold so this app can actually deploy: points the image at the `ghcr.io/kcdragon/community-foundations` registry, targets the production server, and mounts a host-backed block volume for the SQLite/Solid databases and Active Storage files. Enables Kamal's SSL proxy on `community-foundations.rowhomelabs.com` and turns on `assume_ssl`/`force_ssl` in production since the proxy terminates TLS. Sources the registry token from 1Password (with an env-var fallback) and updates the mailer host to the real domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)