### PR TITLE
Resolve org subdomains under the community-foundations apex

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -20,9 +20,13 @@ servers:
 #
 # Don't use this when deploying to multiple web servers (then you have to terminate SSL at your load balancer).
 #
+# Each org is served from its own subdomain of the apex. List every host so the proxy
+# requests a Let's Encrypt cert for each. Add a new line here when an org is onboarded.
 proxy:
   ssl: true
-  host: community-foundations.rowhomelabs.com
+  hosts:
+    - community-foundations.rowhomelabs.com
+    - arlington.community-foundations.rowhomelabs.com
 
 # Where you keep your container images.
 registry:

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -57,6 +57,12 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
+  # The app's apex (community-foundations.rowhomelabs.com) is itself two labels below the
+  # registered domain (rowhomelabs.com), so treat those two labels plus the TLD as the domain.
+  # Then "arlington.community-foundations.rowhomelabs.com" → request.subdomain == "arlington",
+  # and the bare apex → "" (no tenant). Mirrors tld_length = 0 used for "localhost" in dev/test.
+  config.action_dispatch.tld_length = 2
+
   # Set host to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = { host: "community-foundations.rowhomelabs.com" }
 
@@ -79,12 +85,14 @@ Rails.application.configure do
   # Only use :id for inspections in production.
   config.active_record.attributes_for_inspect = [ :id ]
 
-  # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
-  #
-  # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  # Enable DNS rebinding protection and other `Host` header attacks. Allow the apex (landing
+  # page) plus any org subdomain like "arlington.community-foundations.rowhomelabs.com".
+  config.hosts = [
+    "community-foundations.rowhomelabs.com",
+    /\A[a-z0-9-]+\.community-foundations\.rowhomelabs\.com\z/, # org subdomains
+  ]
+
+  # Skip DNS rebinding protection for the default health check endpoint (kamal-proxy hits
+  # "/up" directly on the container, without the public Host header).
+  config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end


### PR DESCRIPTION
Production used Rails' default `tld_length = 1`, so it treated `rowhomelabs.com` as the domain and mis-parsed every request — the apex resolved `request.subdomain` to `"community-foundations"` (404 instead of the landing page) and `arlington.community-foundations.rowhomelabs.com` to `"arlington.community-foundations"` (no matching org). This sets `tld_length = 2` so the apex is the domain and org subdomains resolve to the right `Organization`. It also enables `config.hosts` for the apex plus org subdomains (excluding the `/up` health check) and lists each org host in the kamal proxy so it issues a per-host Let's Encrypt cert.

Deploying requires DNS for the org host(s) pointing at the server and a proxy reboot so the certs are issued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)