### PR TITLE
Let users resend the confirmation email

### DIFF
--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -1,5 +1,19 @@
 class EmailConfirmationsController < ApplicationController
-  allow_unauthenticated_access only: :show
+  allow_unauthenticated_access only: %i[ new create show ]
+  rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to new_email_confirmation_path, alert: "Try again later." }
+
+  def new
+  end
+
+  def create
+    user = User.find_by(email_address: params[:email_address])
+
+    if user && !user.confirmed?
+      RegistrationMailer.confirmation(user, Current.organization).deliver_later
+    end
+
+    redirect_to new_session_path, notice: "Confirmation instructions sent (if an unconfirmed account with that email address exists)."
+  end
 
   def show
     if user = User.find_by_token_for(:email_confirmation, params[:token])

--- a/app/views/email_confirmations/new.html.erb
+++ b/app/views/email_confirmations/new.html.erb
@@ -1,0 +1,15 @@
+<div class="mx-auto max-w-md w-full px-4 py-16">
+  <div class="rounded-2xl border border-line bg-surface p-8 shadow-sm">
+    <h1 class="font-serif font-medium text-3xl tracking-tight text-ink">Resend confirmation email</h1>
+
+    <%= form_with url: email_confirmation_path, class: "contents" do |form| %>
+      <div class="my-5">
+        <%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email_address], class: "block shadow-sm rounded-md border border-line bg-surface px-3 py-2 mt-2 w-full focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
+      </div>
+
+      <div class="inline">
+        <%= form.submit "Email confirmation instructions", class: "w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 bg-accent hover:bg-[#444] text-white inline-block font-medium cursor-pointer transition" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -20,6 +20,8 @@
           <%= link_to "Sign up", new_registration_path, class: "text-ink hover:text-brand underline" %>
           &middot;
           <%= link_to "Forgot password?", new_password_path, class: "text-ink hover:text-brand underline" %>
+          &middot;
+          <%= link_to "Resend confirmation", new_email_confirmation_path, class: "text-ink hover:text-brand underline" %>
         </div>
       </div>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   resource :home
   resources :passwords, param: :token
   resource :registration, only: %i[ new create ]
-  resource :email_confirmation, only: :show
+  resource :email_confirmation, only: %i[ new create show ]
   resource :session
 
   resources :scenarios do

--- a/test/controllers/email_confirmations_controller_test.rb
+++ b/test/controllers/email_confirmations_controller_test.rb
@@ -6,6 +6,38 @@ class EmailConfirmationsControllerTest < ActionDispatch::IntegrationTest
     @user = users(:unconfirmed)
   end
 
+  test "new" do
+    get new_email_confirmation_path
+    assert_response :success
+  end
+
+  test "create for an unconfirmed user enqueues a confirmation email" do
+    post email_confirmation_path, params: { email_address: @user.email_address }
+    assert_enqueued_email_with RegistrationMailer, :confirmation, args: [ @user, organizations(:arlington) ]
+    assert_redirected_to new_session_path
+
+    follow_redirect!
+    assert_notice "Confirmation instructions sent"
+  end
+
+  test "create for an already-confirmed user sends no mail" do
+    post email_confirmation_path, params: { email_address: users(:one).email_address }
+    assert_enqueued_emails 0
+    assert_redirected_to new_session_path
+
+    follow_redirect!
+    assert_notice "Confirmation instructions sent"
+  end
+
+  test "create for an unknown email sends no mail and reveals nothing" do
+    post email_confirmation_path, params: { email_address: "missing-user@example.com" }
+    assert_enqueued_emails 0
+    assert_redirected_to new_session_path
+
+    follow_redirect!
+    assert_notice "Confirmation instructions sent"
+  end
+
   test "show with a valid token confirms the user and signs them in" do
     token = @user.generate_token_for(:email_confirmation)
 
@@ -32,5 +64,10 @@ class EmailConfirmationsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to new_session_path
     assert_nil cookies[:session_id]
+  end
+
+  private
+  def assert_notice(text)
+    assert_select "div", /#{text}/
   end
 end


### PR DESCRIPTION
Adds a recovery path for users who lose or expire their confirmation email — previously they could neither sign in (blocked until confirmed) nor re-register (emails are globally unique). A new unauthenticated page at `/email_confirmation/new`, plus a "Resend confirmation" link on the sign-in page, lets them enter their email to re-send the confirmation link, mirroring the existing password-reset flow. Only unconfirmed accounts are actually mailed, and the action always shows the same generic notice so it never reveals whether an email exists or is already confirmed. It reuses the existing `RegistrationMailer.confirmation` and the on-demand `email_confirmation` token, so no model or schema changes were needed. Controller tests cover the form, the unconfirmed send, and the two no-leak cases (already-confirmed and unknown email).

🤖 Generated with [Claude Code](https://claude.com/claude-code)