### PR TITLE
Add dev-only /auto_sign_in path to sign in the first user

### DIFF
--- a/app/controllers/auto_sign_in_controller.rb
+++ b/app/controllers/auto_sign_in_controller.rb
@@ -1,0 +1,21 @@
+class AutoSignInController < ApplicationController
+  allow_unauthenticated_access
+  allow_without_organization
+
+  before_action :ensure_development
+
+  def create
+    if (user = User.first)
+      start_new_session_for user
+      redirect_to root_path
+    else
+      redirect_to new_registration_path, alert: "No users exist yet."
+    end
+  end
+
+  private
+
+  def ensure_development
+    raise ActionController::RoutingError, "Not Found" unless Rails.env.development?
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,9 @@ Rails.application.routes.draw do
   resource :email_confirmation, only: %i[ new create show ]
   resource :session
 
+  # Dev-only convenience: sign in as the first user without a password
+  get "auto_sign_in", to: "auto_sign_in#create" if Rails.env.development?
+
   resources :scenarios do
     resource :name, only: %i[ show edit update ], module: :scenarios
     resources :allocations, only: %i[ create update destroy ]


### PR DESCRIPTION
Adds an `/auto_sign_in` path that signs in `User.first` without a password to speed up local development. The route is only mounted when `Rails.env.development?`, and the controller adds a defense-in-depth `before_action` that raises a 404 outside development, so it can never act as a backdoor in production. It uses the existing `start_new_session_for` helper so session creation and the signed cookie match normal login, and skips the auth/tenant `before_action`s via `allow_unauthenticated_access` and `allow_without_organization`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)