### PR TITLE
Add passwordless magic-link sign-up and sign-in

### DIFF
--- a/app/controllers/magic_links_controller.rb
+++ b/app/controllers/magic_links_controller.rb
@@ -1,0 +1,42 @@
+class MagicLinksController < ApplicationController
+  allow_unauthenticated_access only: %i[ new create show ]
+  rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to new_magic_link_path, alert: "Try again later." }
+
+  def new
+  end
+
+  def create
+    # Honeypot: real users never fill this hidden field, bots do
+    if params[:nickname].present?
+      redirect_to new_session_path, notice: generic_notice
+      return
+    end
+
+    user = User.find_by(email_address: params[:email_address])
+
+    # Only send to members of this organization
+    if user&.member_of?(Current.organization)
+      MagicLinkMailer.sign_in_link(user, Current.organization).deliver_later
+    end
+
+    redirect_to new_session_path, notice: generic_notice
+  end
+
+  def show
+    user = User.find_by_token_for(:magic_link, params[:token])
+
+    if user&.member_of?(Current.organization)
+      user.confirm! unless user.confirmed?
+      start_new_session_for user
+      redirect_to after_authentication_url, notice: "You're signed in."
+    else
+      redirect_to new_session_path, alert: "Sign-in link is invalid or has expired."
+    end
+  end
+
+  private
+
+  def generic_notice
+    "If an account exists for that email, we've sent a sign-in link."
+  end
+end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -10,7 +10,7 @@ class RegistrationsController < ApplicationController
     # Honeypot: real users never fill this hidden field, bots do. Silently
     # pretend success so spammers can't tell their submission was rejected.
     if params[:nickname].present?
-      redirect_to new_session_path, notice: "Check your email to confirm your account before signing in."
+      redirect_to new_session_path, notice: confirmation_notice
       return
     end
 
@@ -29,14 +29,24 @@ class RegistrationsController < ApplicationController
         Current.organization.organization_memberships.create!(user: @user)
       end
 
-      RegistrationMailer.confirmation(@user, Current.organization).deliver_later
-      redirect_to new_session_path, notice: "Check your email to confirm your account before signing in."
+      if @user.password_set?
+        RegistrationMailer.confirmation(@user, Current.organization).deliver_later
+        redirect_to new_session_path, notice: confirmation_notice
+      else
+        # Passwordless signup: send a magic link that confirms and signs them in.
+        MagicLinkMailer.sign_in_link(@user, Current.organization).deliver_later
+        redirect_to new_session_path, notice: "Check your email for a sign-in link."
+      end
     else
       render :new, status: :unprocessable_entity
     end
   end
 
   private
+
+  def confirmation_notice
+    "Check your email to confirm your account before signing in."
+  end
 
   def registration_params
     params.require(:user).permit(:email_address, :password, :password_confirmation)

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,29 @@
+class Users::PasswordsController < ApplicationController
+  def show
+    @user = Current.user
+  end
+
+  def update
+    @user = Current.user
+
+    # Users who already have a password must confirm it before changing it.
+    # Passwordless users are adding their first password, so none is required.
+    if @user.password_set? && !@user.authenticate(params[:current_password].to_s)
+      @user.errors.add(:current_password, "is incorrect")
+      render :show, status: :unprocessable_entity
+      return
+    end
+
+    if @user.update(password_params)
+      redirect_to users_password_path, notice: "Password saved."
+    else
+      render :show, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def password_params
+    params.require(:user).permit(:password, :password_confirmation)
+  end
+end

--- a/app/mailers/magic_link_mailer.rb
+++ b/app/mailers/magic_link_mailer.rb
@@ -1,0 +1,7 @@
+class MagicLinkMailer < ApplicationMailer
+  def sign_in_link(user, organization)
+    @user = user
+    @organization = organization
+    mail subject: "Your sign-in link", to: user.email_address
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,8 @@
 class User < ApplicationRecord
-  has_secure_password
+  # validations: false so a password isn't required on create — passwordless
+  # (magic-link) accounts have none. The presence-on-create check is dropped;
+  # the length/confirmation validations below replace the rest.
+  has_secure_password validations: false
   has_many :sessions, dependent: :destroy
   has_many :organization_memberships, dependent: :destroy
   has_many :organizations, through: :organization_memberships
@@ -9,13 +12,24 @@ class User < ApplicationRecord
     confirmed_at
   end
 
+  # Magic-link sign-in token. Tied to the password salt so the link
+  # auto-invalidates the moment a password is set or changed.
+  generates_token_for :magic_link, expires_in: 30.minutes do
+    password_salt&.last(10)
+  end
+
   normalizes :email_address, with: ->(e) { e.strip.downcase }
 
   validates :email_address, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
-  validates :password, length: { minimum: 8 }, allow_nil: true
+  validates :password, length: { minimum: 8, maximum: ActiveModel::SecurePassword::MAX_PASSWORD_LENGTH_ALLOWED }, allow_nil: true
+  validates :password, confirmation: true, allow_blank: true
 
   def member_of?(organization)
     organization && organizations.exists?(organization.id)
+  end
+
+  def password_set?
+    password_digest.present?
   end
 
   def confirmed?

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,6 +31,18 @@
     <nav class="sticky top-0 z-50 flex h-13 items-center border-b border-line bg-surface px-6 sm:px-9">
       <%= link_to (Current.organization&.name || "Community Foundations"), root_path,
             class: "font-serif text-lg tracking-tight text-ink hover:text-ink" %>
+
+      <% if Rails.env.development? || authenticated? %>
+        <div class="ml-auto flex items-center gap-4 text-sm">
+          <% if Rails.env.development? %>
+            <%= link_to "Mailer previews", "/rails/mailers", class: "text-ink-soft hover:text-ink" %>
+          <% end %>
+          <% if authenticated? %>
+            <%= link_to "Settings", users_password_path, class: "text-ink-soft hover:text-ink" %>
+            <%= button_to "Sign out", session_path, method: :delete, class: "text-ink-soft hover:text-ink cursor-pointer" %>
+          <% end %>
+        </div>
+      <% end %>
     </nav>
 
     <%= render "shared/flash" %>

--- a/app/views/magic_link_mailer/sign_in_link.html.erb
+++ b/app/views/magic_link_mailer/sign_in_link.html.erb
@@ -1,0 +1,6 @@
+<p>
+  Sign in by visiting
+  <%= link_to "this sign-in page", magic_link_url(token: @user.generate_token_for(:magic_link), subdomain: @organization.subdomain) %>.
+
+  This link will expire in 30 minutes.
+</p>

--- a/app/views/magic_link_mailer/sign_in_link.text.erb
+++ b/app/views/magic_link_mailer/sign_in_link.text.erb
@@ -1,0 +1,4 @@
+Sign in by visiting
+<%= magic_link_url(token: @user.generate_token_for(:magic_link), subdomain: @organization.subdomain) %>
+
+This link will expire in 30 minutes.

--- a/app/views/magic_links/new.html.erb
+++ b/app/views/magic_links/new.html.erb
@@ -1,0 +1,29 @@
+<div class="mx-auto max-w-md w-full px-4 py-16">
+  <div class="rounded-2xl border border-line bg-surface p-8 shadow-sm">
+    <h1 class="font-serif font-medium text-3xl tracking-tight text-ink">Email me a sign-in link</h1>
+
+    <p class="mt-3 text-sm text-ink-soft">We'll email you a link that signs you in — no password needed.</p>
+
+    <%= form_with url: magic_link_path, class: "contents" do |form| %>
+      <%# Honeypot: hidden from real users, but bots tend to fill every field. Submissions with this set are silently dropped. %>
+      <div class="absolute left-[-9999px]" aria-hidden="true">
+        <%= label_tag :nickname, "Leave this field blank" %>
+        <%= text_field_tag :nickname, nil, tabindex: -1, autocomplete: "off" %>
+      </div>
+
+      <div class="my-5">
+        <%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email_address], class: "block shadow-sm rounded-md border border-line bg-surface px-3 py-2 mt-2 w-full focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
+      </div>
+
+      <div class="mt-6 sm:flex sm:items-center sm:gap-4">
+        <div class="inline">
+          <%= form.submit "Email me a sign-in link", class: "w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 bg-accent hover:bg-[#444] text-white inline-block font-medium cursor-pointer transition" %>
+        </div>
+
+        <div class="mt-4 text-sm text-ink-soft sm:mt-0">
+          <%= link_to "Sign in with a password", new_session_path, class: "text-ink hover:text-brand underline" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -24,11 +24,12 @@
       </div>
 
       <div class="my-5">
-        <%= form.password_field :password, required: true, autocomplete: "new-password", minlength: 8, placeholder: "Enter your password (min. 8 characters)", maxlength: 72, class: "block shadow-sm rounded-md border border-line bg-surface px-3 py-2 mt-2 w-full focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
+        <%= form.password_field :password, autocomplete: "new-password", minlength: 8, placeholder: "Choose a password (min. 8 characters)", maxlength: 72, class: "block shadow-sm rounded-md border border-line bg-surface px-3 py-2 mt-2 w-full focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
+        <p class="mt-2 text-sm text-ink-soft">Optional — leave blank to sign in with a link emailed to you instead.</p>
       </div>
 
       <div class="my-5">
-        <%= form.password_field :password_confirmation, required: true, autocomplete: "new-password", placeholder: "Confirm your password", maxlength: 72, class: "block shadow-sm rounded-md border border-line bg-surface px-3 py-2 mt-2 w-full focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
+        <%= form.password_field :password_confirmation, autocomplete: "new-password", placeholder: "Confirm your password", maxlength: 72, class: "block shadow-sm rounded-md border border-line bg-surface px-3 py-2 mt-2 w-full focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
       </div>
 
       <div class="mt-6 sm:flex sm:items-center sm:gap-4">

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -19,6 +19,8 @@
         <div class="mt-4 text-sm text-ink-soft sm:mt-0">
           <%= link_to "Sign up", new_registration_path, class: "text-ink hover:text-brand underline" %>
           &middot;
+          <%= link_to "Email me a sign-in link", new_magic_link_path, class: "text-ink hover:text-brand underline" %>
+          &middot;
           <%= link_to "Forgot password?", new_password_path, class: "text-ink hover:text-brand underline" %>
           &middot;
           <%= link_to "Resend confirmation", new_email_confirmation_path, class: "text-ink hover:text-brand underline" %>

--- a/app/views/users/passwords/show.html.erb
+++ b/app/views/users/passwords/show.html.erb
@@ -1,0 +1,44 @@
+<div class="mx-auto max-w-md w-full px-4 py-16">
+  <div class="rounded-2xl border border-line bg-surface p-8 shadow-sm">
+    <h1 class="font-serif font-medium text-3xl tracking-tight text-ink">
+      <%= @user.password_set? ? "Change password" : "Add a password" %>
+    </h1>
+
+    <p class="mt-3 text-sm text-ink-soft">
+      <%= @user.password_set? ? "Update the password you use to sign in." : "Add a password so you can sign in without a magic link." %>
+    </p>
+
+    <%= form_with url: users_password_path, method: :patch, scope: :user, class: "contents" do |form| %>
+      <% if @user.errors.any? %>
+        <div class="mt-5 py-2 px-3 bg-danger-tint text-danger font-medium rounded-lg" id="error_explanation">
+          <ul class="list-disc list-inside">
+            <% @user.errors.full_messages.each do |message| %>
+              <li><%= message %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+      <% if @user.password_set? %>
+        <div class="my-5">
+          <%= label_tag :current_password, "Current password", class: "text-sm font-medium text-ink" %>
+          <%= password_field_tag :current_password, nil, required: true, autocomplete: "current-password", placeholder: "Enter your current password", maxlength: 72, class: "block shadow-sm rounded-md border border-line bg-surface px-3 py-2 mt-2 w-full focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
+        </div>
+      <% end %>
+
+      <div class="my-5">
+        <%= form.label :password, "New password", class: "text-sm font-medium text-ink" %>
+        <%= form.password_field :password, required: true, autocomplete: "new-password", minlength: 8, placeholder: "Choose a password (min. 8 characters)", maxlength: 72, class: "block shadow-sm rounded-md border border-line bg-surface px-3 py-2 mt-2 w-full focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
+      </div>
+
+      <div class="my-5">
+        <%= form.label :password_confirmation, "Confirm new password", class: "text-sm font-medium text-ink" %>
+        <%= form.password_field :password_confirmation, required: true, autocomplete: "new-password", placeholder: "Confirm your password", maxlength: 72, class: "block shadow-sm rounded-md border border-line bg-surface px-3 py-2 mt-2 w-full focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
+      </div>
+
+      <div class="mt-6 inline">
+        <%= form.submit "Save password", class: "w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 bg-accent hover:bg-[#444] text-white inline-block font-medium cursor-pointer transition" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,10 @@ Rails.application.routes.draw do
   resources :passwords, param: :token
   resource :registration, only: %i[ new create ]
   resource :email_confirmation, only: %i[ new create show ]
+  resource :magic_link, only: %i[ new create show ]
+  namespace :users do
+    resource :password, only: %i[ show update ]
+  end
   resource :session
 
   resources :scenarios do

--- a/db/migrate/20260615120000_allow_null_password_digest.rb
+++ b/db/migrate/20260615120000_allow_null_password_digest.rb
@@ -1,0 +1,7 @@
+class AllowNullPasswordDigest < ActiveRecord::Migration[8.1]
+  def change
+    # Passwordless (magic-link) accounts have no password, so password_digest
+    # must be allowed to be NULL.
+    change_column_null :users, :password_digest, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_11_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_15_120000) do
   create_table "allocations", force: :cascade do |t|
     t.integer "scenario_id", null: false
     t.string "type", null: false
@@ -64,7 +64,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_11_120000) do
 
   create_table "users", force: :cascade do |t|
     t.string "email_address", null: false
-    t.string "password_digest", null: false
+    t.string "password_digest"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "confirmed_at"

--- a/test/controllers/magic_links_controller_test.rb
+++ b/test/controllers/magic_links_controller_test.rb
@@ -1,0 +1,93 @@
+require "test_helper"
+
+class MagicLinksControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    host! "arlington.localhost"
+    @member = users(:one) # member of arlington
+  end
+
+  test "new" do
+    get new_magic_link_path
+    assert_response :success
+  end
+
+  test "create for a member enqueues a sign-in link" do
+    post magic_link_path, params: { email_address: @member.email_address }
+
+    assert_enqueued_email_with MagicLinkMailer, :sign_in_link, args: [ @member, organizations(:arlington) ]
+    assert_redirected_to new_session_path
+
+    follow_redirect!
+    assert_select "div", /we've sent a sign-in link/
+  end
+
+  test "create for a passwordless member enqueues a sign-in link" do
+    post magic_link_path, params: { email_address: users(:passwordless).email_address }
+
+    assert_enqueued_email_with MagicLinkMailer, :sign_in_link, args: [ users(:passwordless), organizations(:arlington) ]
+    assert_redirected_to new_session_path
+  end
+
+  test "create for a non-member of this org sends no mail and reveals nothing" do
+    post magic_link_path, params: { email_address: users(:two).email_address } # member of boston
+
+    assert_enqueued_emails 0
+    assert_redirected_to new_session_path
+    follow_redirect!
+    assert_select "div", /we've sent a sign-in link/
+  end
+
+  test "create for an unknown email sends no mail and reveals nothing" do
+    post magic_link_path, params: { email_address: "missing-user@example.com" }
+
+    assert_enqueued_emails 0
+    assert_redirected_to new_session_path
+    follow_redirect!
+    assert_select "div", /we've sent a sign-in link/
+  end
+
+  test "create with the honeypot filled is silently dropped" do
+    assert_no_enqueued_emails do
+      post magic_link_path, params: { nickname: "spammy mcbot", email_address: @member.email_address }
+    end
+
+    assert_redirected_to new_session_path
+  end
+
+  test "show with a valid token for a confirmed member signs them in" do
+    token = @member.generate_token_for(:magic_link)
+
+    get magic_link_path(token: token)
+
+    assert_redirected_to root_url
+    assert cookies[:session_id]
+  end
+
+  test "show with a valid token for an unconfirmed passwordless signup confirms and signs in" do
+    user = User.create!(email_address: "fresh@example.com")
+    organizations(:arlington).organization_memberships.create!(user: user)
+    token = user.generate_token_for(:magic_link)
+
+    get magic_link_path(token: token)
+
+    assert user.reload.confirmed?
+    assert_redirected_to root_url
+    assert cookies[:session_id]
+  end
+
+  test "show with an invalid token" do
+    get magic_link_path(token: "invalid")
+
+    assert_redirected_to new_session_path
+    assert_nil cookies[:session_id]
+  end
+
+  test "show with a token for a user in another org is rejected" do
+    token = users(:two).generate_token_for(:magic_link) # member of boston, not arlington
+
+    get magic_link_path(token: token)
+
+    assert_redirected_to new_session_path
+    assert_nil cookies[:session_id]
+  end
+end

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -31,6 +31,24 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
     assert user.member_of?(organizations(:arlington))
   end
 
+  test "create without a password creates a passwordless user and emails a sign-in link" do
+    assert_difference -> { User.count }, 1 do
+      assert_difference -> { OrganizationMembership.count }, 1 do
+        post registration_path, params: {
+          user: { email_address: "magic@example.com", password: "", password_confirmation: "" }
+        }
+      end
+    end
+
+    user = User.find_by(email_address: "magic@example.com")
+    assert_not user.password_set?
+    assert user.member_of?(organizations(:arlington))
+    assert_enqueued_email_with MagicLinkMailer, :sign_in_link, args: [ user, organizations(:arlington) ]
+
+    assert_redirected_to new_session_path
+    assert_nil cookies[:session_id]
+  end
+
   test "create with the honeypot filled is silently dropped" do
     assert_no_difference -> { User.count } do
       assert_no_enqueued_emails do

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -18,6 +18,13 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert cookies[:session_id]
   end
 
+  test "create for a passwordless user via the password form fails gracefully" do
+    post session_path, params: { email_address: users(:passwordless).email_address, password: "anything" }
+
+    assert_redirected_to new_session_path
+    assert_nil cookies[:session_id]
+  end
+
   test "create with invalid credentials" do
     post session_path, params: { email_address: @user.email_address, password: "wrong" }
 

--- a/test/controllers/users/passwords_controller_test.rb
+++ b/test/controllers/users/passwords_controller_test.rb
@@ -1,0 +1,79 @@
+require "test_helper"
+
+class Users::PasswordsControllerTest < ActionDispatch::IntegrationTest
+  setup { host! "arlington.localhost" }
+
+  test "show requires authentication" do
+    get users_password_path
+    assert_redirected_to new_session_path
+  end
+
+  test "show for an authenticated user" do
+    sign_in_as users(:one)
+    get users_password_path
+    assert_response :success
+  end
+
+  test "a passwordless user adds a first password without a current password" do
+    user = users(:passwordless)
+    sign_in_as user
+
+    patch users_password_path, params: {
+      user: { password: "secret123", password_confirmation: "secret123" }
+    }
+
+    assert_redirected_to users_password_path
+    assert user.reload.password_set?
+    assert user.authenticate("secret123")
+  end
+
+  test "a user with a password must supply the correct current password" do
+    user = users(:one)
+    sign_in_as user
+
+    patch users_password_path, params: {
+      current_password: "wrong",
+      user: { password: "newsecret123", password_confirmation: "newsecret123" }
+    }
+
+    assert_response :unprocessable_entity
+    assert_not user.reload.authenticate("newsecret123")
+  end
+
+  test "a user with a password can change it with the correct current password" do
+    user = users(:one)
+    sign_in_as user
+
+    patch users_password_path, params: {
+      current_password: "password",
+      user: { password: "newsecret123", password_confirmation: "newsecret123" }
+    }
+
+    assert_redirected_to users_password_path
+    assert user.reload.authenticate("newsecret123")
+  end
+
+  test "rejects a too-short password" do
+    user = users(:passwordless)
+    sign_in_as user
+
+    patch users_password_path, params: {
+      user: { password: "short", password_confirmation: "short" }
+    }
+
+    assert_response :unprocessable_entity
+    assert_not user.reload.password_set?
+  end
+
+  test "rejects a mismatched confirmation" do
+    user = users(:passwordless)
+    sign_in_as user
+
+    patch users_password_path, params: {
+      user: { password: "secret123", password_confirmation: "nomatch" }
+    }
+
+    assert_response :unprocessable_entity
+    assert_not user.reload.password_set?
+  end
+end

--- a/test/fixtures/organization_memberships.yml
+++ b/test/fixtures/organization_memberships.yml
@@ -5,3 +5,7 @@ one_arlington:
 two_boston:
   user: two
   organization: boston
+
+passwordless_arlington:
+  user: passwordless
+  organization: arlington

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -14,3 +14,8 @@ unconfirmed:
   email_address: unconfirmed@example.com
   password_digest: <%= password_digest %>
   confirmed_at: <%= nil %>
+
+# Passwordless (magic-link) member of arlington — no password_digest.
+passwordless:
+  email_address: passwordless@example.com
+  confirmed_at: <%= Time.current.to_fs(:db) %>

--- a/test/mailers/magic_link_mailer_test.rb
+++ b/test/mailers/magic_link_mailer_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class MagicLinkMailerTest < ActionMailer::TestCase
+  test "sign_in_link" do
+    user = users(:passwordless)
+    organization = organizations(:arlington)
+
+    mail = MagicLinkMailer.sign_in_link(user, organization)
+
+    assert_equal "Your sign-in link", mail.subject
+    assert_equal [ user.email_address ], mail.to
+    assert_equal [ "no-reply@community-foundations.rowhomelabs.com" ], mail.from
+
+    # Both parts link to the org's subdomain and carry a working magic-link token.
+    [ mail.html_part, mail.text_part ].each do |part|
+      body = part.body.to_s
+
+      assert_match "http://#{organization.subdomain}.localhost/magic_link", body
+
+      token = CGI.unescape(body[/token=([^"&\s]+)/, 1])
+      assert_equal user, User.find_by_token_for(:magic_link, token)
+    end
+  end
+end

--- a/test/mailers/previews/magic_link_mailer_preview.rb
+++ b/test/mailers/previews/magic_link_mailer_preview.rb
@@ -1,0 +1,5 @@
+class MagicLinkMailerPreview < ActionMailer::Preview
+  def sign_in_link
+    MagicLinkMailer.sign_in_link(User.take, Organization.take)
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -15,4 +15,25 @@ class UserTest < ActiveSupport::TestCase
     assert_not users(:one).member_of?(organizations(:boston))
     assert_not users(:one).member_of?(nil)
   end
+
+  test "is valid without a password" do
+    user = User.new(email_address: "passwordless@example.org")
+    assert user.valid?
+    assert_not user.password_set?
+  end
+
+  test "magic_link token round-trips" do
+    user = users(:one)
+    token = user.generate_token_for(:magic_link)
+    assert_equal user, User.find_by_token_for(:magic_link, token)
+  end
+
+  test "setting a password invalidates an outstanding magic_link token" do
+    user = users(:passwordless)
+    token = user.generate_token_for(:magic_link)
+
+    user.update!(password: "secret123", password_confirmation: "secret123")
+
+    assert_nil User.find_by_token_for(:magic_link, token)
+  end
 end


### PR DESCRIPTION
Adds passwordless authentication: users can sign up and sign in with email only, receiving a 30-minute magic link instead of using a password, alongside the existing password flow. `password_digest` is now nullable and `User` carries a `:magic_link` token tied to `password_salt` so the link auto-invalidates once a password is set or changed. A new `MagicLinksController`/`MagicLinkMailer` handle requesting and consuming sign-in links with honeypot, rate limiting, org-membership gating, and account-existence non-disclosure matching the existing auth controllers. Passwordless users can later add a password from a new account settings page (`Users::PasswordsController`), and a dev-only "Mailer previews" nav link was added. Full test coverage for the new controllers, mailer, and model behavior is included (103 tests passing, Rubocop and Brakeman clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)