### PR TITLE
Add allocation hints to scenario view

### DIFF
--- a/app/views/scenarios/show.html.erb
+++ b/app/views/scenarios/show.html.erb
@@ -22,6 +22,7 @@
     <!-- Allocations -->
     <div class="rounded-2xl border border-line bg-surface p-6 shadow-sm">
       <h2 class="font-serif font-medium text-xl text-ink">Allocations</h2>
+      <p class="mt-2 text-sm text-ink-soft">Decide where your giving goes each year, then add one-time gifts.</p>
 
       <%= render "allocation_section",
             title: "On going giving",
@@ -37,6 +38,7 @@
     <!-- Summary -->
     <div class="rounded-2xl border border-line bg-surface p-6 shadow-sm">
       <h2 class="font-serif font-medium text-xl text-ink">Allocation summary</h2>
+      <p class="mt-2 text-sm text-ink-soft">Set your total above to see a full breakdown.</p>
 
       <div class="mt-5">
         <h3 class="text-[11px] font-semibold uppercase tracking-wide text-ink-faint">On going giving</h3>


### PR DESCRIPTION
Add descriptive hints below the "Allocations" and "Allocation summary" section headings to guide users through the giving allocation workflow.

- "Decide where your giving goes each year, then add one-time gifts." under Allocations
- "Set your total above to see a full breakdown." under Allocation summary

These hints help users understand the purpose of each section at a glance.