### PR TITLE
Improve empty-state text for allocation sections

### DIFF
--- a/app/views/scenarios/_allocation_section.html.erb
+++ b/app/views/scenarios/_allocation_section.html.erb
@@ -14,7 +14,7 @@
     </div>
   <% else %>
     <div class="mt-3 rounded-xl border border-line-soft bg-surface-soft py-12 text-center text-ink-faint">
-      Start to create allocation
+      There are no <%= title.downcase %> allocations yet
     </div>
   <% end %>
 


### PR DESCRIPTION
Replaces the placeholder "Start to create allocation" empty-state text with a clearer message that names the section, e.g. "There are no one time giving allocations yet".

🤖 Generated with [Claude Code](https://claude.com/claude-code)