### PR TITLE
Make scenario total giving amount inline-editable

### DIFF
--- a/app/controllers/scenarios/total_giving_amounts_controller.rb
+++ b/app/controllers/scenarios/total_giving_amounts_controller.rb
@@ -1,0 +1,27 @@
+class Scenarios::TotalGivingAmountsController < ApplicationController
+  before_action :set_scenario
+
+  def show
+  end
+
+  def edit
+  end
+
+  def update
+    if @scenario.update(total_giving_amount_params)
+      render :show
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_scenario
+    @scenario = Current.user.scenarios.where(organization: Current.organization).find(params[:scenario_id])
+  end
+
+  def total_giving_amount_params
+    params.require(:scenario).permit(:total_giving_amount)
+  end
+end

--- a/app/views/scenarios/show.html.erb
+++ b/app/views/scenarios/show.html.erb
@@ -4,19 +4,7 @@
 
   <%= render "scenarios/names/name", scenario: @scenario %>
 
-  <%= form_with model: @scenario, class: "contents" do |form| %>
-    <div class="mt-6 rounded-2xl border border-line bg-surface p-6 shadow-sm">
-      <div class="flex items-center gap-4">
-        <%= form.label :total_giving_amount, "Total giving amount", class: "w-40 text-ink-soft" %>
-        <div class="relative max-w-md w-full">
-          <span class="absolute left-3 top-1/2 -translate-y-1/2 text-ink-faint">$</span>
-          <%= form.number_field :total_giving_amount, step: "1", min: 0, placeholder: "0",
-                class: "block w-full rounded-md border border-line bg-surface-soft pl-7 pr-3 py-2 shadow-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
-        </div>
-        <%= form.submit "Save", class: "rounded-md px-3.5 py-2 bg-accent hover:bg-[#444] text-white text-sm font-medium cursor-pointer transition" %>
-      </div>
-    </div>
-  <% end %>
+  <%= render "scenarios/total_giving_amounts/total_giving_amount", scenario: @scenario %>
 
   <div class="mt-8 grid gap-6 lg:grid-cols-2">
     <!-- Allocations -->

--- a/app/views/scenarios/total_giving_amounts/_form.html.erb
+++ b/app/views/scenarios/total_giving_amounts/_form.html.erb
@@ -1,0 +1,26 @@
+<%= turbo_frame_tag dom_id(scenario, :total_giving_amount), class: "mt-6 block" do %>
+  <div class="rounded-2xl border border-line bg-surface p-6 shadow-sm">
+    <%= form_with model: scenario, url: scenario_total_giving_amount_path(scenario), method: :patch, class: "flex items-center gap-4" do |form| %>
+      <%= form.label :total_giving_amount, "Total giving amount", class: "w-40 text-ink-soft" %>
+      <div class="relative max-w-md w-full">
+        <span class="absolute left-3 top-1/2 -translate-y-1/2 text-ink-faint">$</span>
+        <%= form.number_field :total_giving_amount, step: "1", min: 0, autofocus: true, placeholder: "0",
+              class: "block w-full rounded-md border border-line bg-surface-soft pl-7 pr-3 py-2 shadow-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
+      </div>
+
+      <button type="submit" aria-label="Save total giving amount"
+              class="inline-flex h-9 w-9 items-center justify-center rounded-md bg-accent text-white transition hover:bg-[#444] cursor-pointer">
+        <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+        </svg>
+      </button>
+
+      <%= link_to scenario_total_giving_amount_path(scenario), aria: { label: "Cancel" },
+            class: "inline-flex h-9 w-9 items-center justify-center rounded-md border border-line bg-surface text-ink-soft transition hover:bg-canvas cursor-pointer" do %>
+        <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/scenarios/total_giving_amounts/_total_giving_amount.html.erb
+++ b/app/views/scenarios/total_giving_amounts/_total_giving_amount.html.erb
@@ -1,0 +1,15 @@
+<%= turbo_frame_tag dom_id(scenario, :total_giving_amount), class: "mt-6 block" do %>
+  <div class="rounded-2xl border border-line bg-surface p-6 shadow-sm">
+    <div class="flex items-center gap-4">
+      <span class="w-40 text-ink-soft">Total giving amount</span>
+      <%= link_to edit_scenario_total_giving_amount_path(scenario), class: "group inline-flex items-center gap-2" do %>
+        <span class="font-medium text-ink"><%= number_to_currency(scenario.total_giving_amount, precision: 0) %></span>
+        <span class="text-ink-faint opacity-0 transition group-hover:opacity-100" aria-hidden="true">
+          <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931z" />
+          </svg>
+        </span>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/scenarios/total_giving_amounts/edit.html.erb
+++ b/app/views/scenarios/total_giving_amounts/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render "scenarios/total_giving_amounts/form", scenario: @scenario %>

--- a/app/views/scenarios/total_giving_amounts/show.html.erb
+++ b/app/views/scenarios/total_giving_amounts/show.html.erb
@@ -1,0 +1,1 @@
+<%= render "scenarios/total_giving_amounts/total_giving_amount", scenario: @scenario %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
 
   resources :scenarios do
     resource :name, only: %i[ show edit update ], module: :scenarios
+    resource :total_giving_amount, only: %i[ show edit update ], module: :scenarios
     resources :allocations, only: %i[ create update destroy ]
   end
 

--- a/test/controllers/scenarios/total_giving_amounts_controller_test.rb
+++ b/test/controllers/scenarios/total_giving_amounts_controller_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class Scenarios::TotalGivingAmountsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    host! "arlington.localhost"
+    sign_in_as users(:one)
+    @scenario = scenarios(:one_arlington)
+  end
+
+  test "show renders the inline total giving amount frame" do
+    get scenario_total_giving_amount_url(@scenario)
+    assert_response :success
+    assert_select "turbo-frame##{dom_id(@scenario, :total_giving_amount)}"
+  end
+
+  test "edit renders the inline total giving amount form" do
+    get edit_scenario_total_giving_amount_url(@scenario)
+    assert_response :success
+    assert_select "turbo-frame##{dom_id(@scenario, :total_giving_amount)} form input[name=?]", "scenario[total_giving_amount]"
+  end
+
+  test "update changes the total giving amount" do
+    patch scenario_total_giving_amount_url(@scenario), params: { scenario: { total_giving_amount: 5000 } }
+    assert_response :success
+    assert_equal 5000, @scenario.reload.total_giving_amount
+  end
+
+  test "cannot edit a scenario owned by another user or org" do
+    get edit_scenario_total_giving_amount_url(scenarios(:two_boston))
+    assert_response :not_found
+  end
+end


### PR DESCRIPTION
Replaces the always-visible total giving amount form on the scenario page with the same Turbo Frame edit-in-place pattern already used for the scenario title. The amount now displays as formatted currency with a hover pencil, swaps to an inline `$`-prefixed field with save/cancel on click, and swaps back on save — no full page reload. Adds a `Scenarios::TotalGivingAmountsController` (mirroring `Scenarios::NamesController`), the nested `total_giving_amount` route, the display/edit partials, and controller tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)