### PR TITLE
Render ERB through ReactionView in enhanced mode

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,8 @@ gem "stimulus-rails"
 gem "tailwindcss-rails"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
+# HTML-aware ERB rendering via the Herb engine [https://reactionview.dev]
+gem "reactionview"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 gem "bcrypt", "~> 3.1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,6 +157,13 @@ GEM
       raabro (~> 1.4)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    herb (0.10.1-aarch64-linux-gnu)
+    herb (0.10.1-aarch64-linux-musl)
+    herb (0.10.1-arm-linux-gnu)
+    herb (0.10.1-arm-linux-musl)
+    herb (0.10.1-arm64-darwin)
+    herb (0.10.1-x86_64-linux-gnu)
+    herb (0.10.1-x86_64-linux-musl)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     image_processing (1.14.0)
@@ -290,6 +297,9 @@ GEM
       erb
       psych (>= 4.0.0)
       tsort
+    reactionview (0.3.0)
+      actionview (>= 7.0)
+      herb (>= 0.9.0, < 1.0.0)
     regexp_parser (2.12.0)
     reline (0.6.3)
       io-console (~> 0.5)
@@ -434,6 +444,7 @@ DEPENDENCIES
   propshaft
   puma (>= 5.0)
   rails!
+  reactionview
   rubocop-rails-omakase
   selenium-webdriver
   solid_cable
@@ -494,6 +505,13 @@ CHECKSUMS
   ffi (1.17.4-x86_64-linux-musl) sha256=3fdf9888483de005f8ef8d1cf2d3b20d86626af206cbf780f6a6a12439a9c49e
   fugit (1.12.2) sha256=643f2bf28db263bd400cbf8e0dd8b76b2c9b94bdb130e12d2394de04d9c20e5e
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
+  herb (0.10.1-aarch64-linux-gnu) sha256=fd9f4f8e0bcd9a421de55ff8810066550e9bcba8c8bf53737b32a04eb2fcbc49
+  herb (0.10.1-aarch64-linux-musl) sha256=bc6dac577c25bb7b35fe812987a9da7056aabd3a9394941c2aadf68bcca7c58e
+  herb (0.10.1-arm-linux-gnu) sha256=965fcb7bb59c7307c2dfdb8fa03ae06724184886bcb015088585e5163036a425
+  herb (0.10.1-arm-linux-musl) sha256=d1c18bf017bccaf32e27439e74e53b3f24bc8056d0ef70e79568ac7f7b2e2728
+  herb (0.10.1-arm64-darwin) sha256=08d0434ae94d23a7353d767085dc974cc5e63943a07cd48bc99afd7fea919c1b
+  herb (0.10.1-x86_64-linux-gnu) sha256=c7762d411a6d2e1a032cf403b0429155c01ab48b3b5be2a0aab1e921da6b8948
+  herb (0.10.1-x86_64-linux-musl) sha256=a5bb7c82bbc30a9eb80cb833fea749f543a0709d9f858f7db366a3c2616d969b
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   image_processing (1.14.0) sha256=754cc169c9c262980889bec6bfd325ed1dafad34f85242b5a07b60af004742fb
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a
@@ -555,6 +573,7 @@ CHECKSUMS
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
   rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
+  reactionview (0.3.0) sha256=3bd363863776827eaf85a9baf75370c1ca52a4b0dad87ba5d672e4abe76eb640
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142

--- a/config/initializers/reactionview.rb
+++ b/config/initializers/reactionview.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+ReActionView.configure do |config|
+  # Intercept .html.erb templates and process them with `Herb::Engine` for enhanced features
+  config.intercept_erb = true
+
+  # Enable debug mode in development (adds debug attributes to HTML)
+  config.debug_mode = Rails.env.development?
+
+  # Validation mode (:raise, :overlay, or :none) — defaults to :raise in test, :overlay otherwise
+  # config.validation_mode = :overlay
+
+  # Add custom transform visitors to process templates before compilation
+  # config.transform_visitors = [
+  #   Herb::Visitor::new
+  # ]
+end


### PR DESCRIPTION
Adds the `reactionview` gem (0.3.0, pulling in `herb` 0.10.1) and enables enhanced mode (`intercept_erb = true`) via a generated `config/initializers/reactionview.rb`, so all existing `.html.erb` templates are processed by the Herb engine — gaining template validation, security checks, and development-only debug attributes. No view files were changed; enhanced mode transparently intercepts the existing ERB. Verified by booting the app (landing page renders 200 with Herb debug attributes) and running the full suite: 123 unit/integration tests and 1 system test, all passing with 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)