### PR TITLE
Let existing users change their email address

### DIFF
--- a/app/controllers/users/emails_controller.rb
+++ b/app/controllers/users/emails_controller.rb
@@ -1,0 +1,67 @@
+class Users::EmailsController < ApplicationController
+  allow_unauthenticated_access only: :confirm
+  rate_limit to: 10, within: 3.minutes, only: :update, with: -> { redirect_to users_email_path, alert: "Try again later." }
+
+  def show
+    @user = Current.user
+  end
+
+  def update
+    @user = Current.user
+
+    if @user.password_set? && !@user.authenticate(params[:current_password].to_s)
+      @user.errors.add(:current_password, "is incorrect")
+      render :show, status: :unprocessable_entity
+      return
+    end
+
+    candidate = params.dig(:user, :unconfirmed_email).to_s.strip.downcase
+
+    if error = email_change_error(candidate)
+      @user.errors.add(:unconfirmed_email, error)
+      render :show, status: :unprocessable_entity
+      return
+    end
+
+    @user.update!(unconfirmed_email: candidate)
+    RegistrationMailer.email_change(@user, Current.organization).deliver_later
+
+    redirect_to users_email_path, notice: "Check #{candidate} for a link to confirm your new email address."
+  end
+
+  def confirm
+    user = User.find_by_token_for(:email_change, params[:token])
+
+    if user.nil? || user.unconfirmed_email.blank?
+      redirect_to new_session_path, alert: "That email confirmation link is invalid or has expired."
+      return
+    end
+
+    target = user.unconfirmed_email
+
+    already_taken = User.where.not(id: user.id).exists?(email_address: target)
+    if already_taken
+      user.update!(unconfirmed_email: nil)
+      redirect_to new_session_path, alert: "That email address is no longer available."
+      return
+    end
+
+    user.update!(email_address: target, unconfirmed_email: nil)
+    redirect_to new_session_path, notice: "Your email address has been updated. Please sign in."
+  rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid
+    user&.update_columns(unconfirmed_email: nil)
+    redirect_to new_session_path, alert: "That email address is no longer available."
+  end
+
+  private
+
+  def email_change_error(candidate)
+    if !User.valid_email_address?(candidate)
+      "is not a valid email address"
+    elsif candidate == @user.email_address
+      "is the same as your current email address"
+    elsif User.where.not(id: @user.id).exists?(email_address: candidate)
+      "is already taken"
+    end
+  end
+end

--- a/app/mailers/registration_mailer.rb
+++ b/app/mailers/registration_mailer.rb
@@ -4,4 +4,10 @@ class RegistrationMailer < ApplicationMailer
     @organization = organization
     mail subject: "Confirm your email address", to: user.email_address
   end
+
+  def email_change(user, organization)
+    @user = user
+    @organization = organization
+    mail subject: "Confirm your new email address", to: user.unconfirmed_email
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,15 +12,25 @@ class User < ApplicationRecord
     confirmed_at
   end
 
+  generates_token_for :email_change, expires_in: 1.day do
+    unconfirmed_email
+  end
+
   # Magic-link sign-in token. Tied to the password salt so the link
   # auto-invalidates the moment a password is set or changed.
   generates_token_for :magic_link, expires_in: 30.minutes do
     password_salt&.last(10)
   end
 
+  EMAIL_ADDRESS_FORMAT = URI::MailTo::EMAIL_REGEXP
+
+  def self.valid_email_address?(value)
+    value.to_s.match?(EMAIL_ADDRESS_FORMAT)
+  end
+
   normalizes :email_address, with: ->(e) { e.strip.downcase }
 
-  validates :email_address, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :email_address, presence: true, uniqueness: true, format: { with: EMAIL_ADDRESS_FORMAT }
   validates :password, length: { minimum: 8, maximum: ActiveModel::SecurePassword::MAX_PASSWORD_LENGTH_ALLOWED }, allow_nil: true
   validates :password, confirmation: true, allow_blank: true
 

--- a/app/views/registration_mailer/email_change.html.erb
+++ b/app/views/registration_mailer/email_change.html.erb
@@ -1,0 +1,6 @@
+<p>
+  Confirm your new email address by visiting
+  <%= link_to "this confirmation page", confirm_users_email_url(token: @user.generate_token_for(:email_change), subdomain: @organization.subdomain) %>.
+
+  This link will expire in 24 hours. If you didn't request this change, you can ignore this email.
+</p>

--- a/app/views/registration_mailer/email_change.text.erb
+++ b/app/views/registration_mailer/email_change.text.erb
@@ -1,0 +1,4 @@
+Confirm your new email address by visiting
+<%= confirm_users_email_url(token: @user.generate_token_for(:email_change), subdomain: @organization.subdomain) %>
+
+This link will expire in 24 hours. If you didn't request this change, you can ignore this email.

--- a/app/views/users/emails/show.html.erb
+++ b/app/views/users/emails/show.html.erb
@@ -1,0 +1,48 @@
+<div class="mx-auto max-w-md w-full px-4 py-16">
+  <div class="rounded-2xl border border-line bg-surface p-8 shadow-sm">
+    <h1 class="font-serif font-medium text-3xl tracking-tight text-ink">Change email</h1>
+
+    <p class="mt-3 text-sm text-ink-soft">
+      Your current email address is <span class="font-medium text-ink"><%= @user.email_address %></span>.
+    </p>
+
+    <% if @user.unconfirmed_email.present? %>
+      <div class="mt-5 py-2 px-3 bg-accent/10 text-ink rounded-lg text-sm">
+        A change to <span class="font-medium"><%= @user.unconfirmed_email %></span> is pending.
+        Check that inbox for the confirmation link. Submitting again replaces it.
+      </div>
+    <% end %>
+
+    <%= form_with url: users_email_path, method: :patch, scope: :user, class: "contents" do |form| %>
+      <% if @user.errors.any? %>
+        <div class="mt-5 py-2 px-3 bg-danger-tint text-danger font-medium rounded-lg" id="error_explanation">
+          <ul class="list-disc list-inside">
+            <% @user.errors.full_messages.each do |message| %>
+              <li><%= message %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+      <% if @user.password_set? %>
+        <div class="my-5">
+          <%= label_tag :current_password, "Current password", class: "text-sm font-medium text-ink" %>
+          <%= password_field_tag :current_password, nil, required: true, autocomplete: "current-password", placeholder: "Enter your current password", maxlength: 72, class: "block shadow-sm rounded-md border border-line bg-surface px-3 py-2 mt-2 w-full focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
+        </div>
+      <% end %>
+
+      <div class="my-5">
+        <%= form.label :unconfirmed_email, "New email address", class: "text-sm font-medium text-ink" %>
+        <%= form.email_field :unconfirmed_email, value: nil, required: true, autocomplete: "email", placeholder: "you@example.com", class: "block shadow-sm rounded-md border border-line bg-surface px-3 py-2 mt-2 w-full focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
+      </div>
+
+      <div class="mt-6 inline">
+        <%= form.submit "Send confirmation link", class: "w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 bg-accent hover:bg-[#444] text-white inline-block font-medium cursor-pointer transition" %>
+      </div>
+    <% end %>
+
+    <p class="mt-6 text-sm text-ink-soft">
+      <%= link_to "Change password instead", users_password_path, class: "text-accent hover:underline" %>
+    </p>
+  </div>
+</div>

--- a/app/views/users/passwords/show.html.erb
+++ b/app/views/users/passwords/show.html.erb
@@ -40,5 +40,9 @@
         <%= form.submit "Save password", class: "w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 bg-accent hover:bg-[#444] text-white inline-block font-medium cursor-pointer transition" %>
       </div>
     <% end %>
+
+    <p class="mt-6 text-sm text-ink-soft">
+      <%= link_to "Change email instead", users_email_path, class: "text-accent hover:underline" %>
+    </p>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,9 @@ Rails.application.routes.draw do
   resource :magic_link, only: %i[ new create show ]
   namespace :users do
     resource :password, only: %i[ show update ]
+    resource :email, only: %i[ show update ] do
+      get :confirm, on: :member
+    end
   end
   resource :session
 

--- a/db/migrate/20260621120000_add_unconfirmed_email_to_users.rb
+++ b/db/migrate/20260621120000_add_unconfirmed_email_to_users.rb
@@ -1,0 +1,5 @@
+class AddUnconfirmedEmailToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :unconfirmed_email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_15_203852) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_21_120000) do
   create_table "allocations", force: :cascade do |t|
     t.integer "scenario_id", null: false
     t.string "type", null: false
@@ -69,6 +69,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_203852) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "confirmed_at"
+    t.string "unconfirmed_email"
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end
 

--- a/test/controllers/users/emails_controller_test.rb
+++ b/test/controllers/users/emails_controller_test.rb
@@ -1,0 +1,186 @@
+require "test_helper"
+
+class Users::EmailsControllerTest < ActionDispatch::IntegrationTest
+  setup { host! "arlington.localhost" }
+
+  test "show requires authentication" do
+    get users_email_path
+    assert_redirected_to new_session_path
+  end
+
+  test "show for an authenticated user" do
+    sign_in_as users(:one)
+    get users_email_path
+    assert_response :success
+  end
+
+  test "a user with a password sets a pending email with the correct current password" do
+    user = users(:one)
+    sign_in_as user
+
+    assert_enqueued_email_with RegistrationMailer, :email_change, args: [user, organizations(:arlington)] do
+      patch users_email_path, params: {
+        current_password: "password",
+        user: { unconfirmed_email: "new@example.com" }
+      }
+    end
+
+    assert_redirected_to users_email_path
+    assert_equal "new@example.com", user.reload.unconfirmed_email
+    assert_equal "one@example.com", user.email_address
+  end
+
+  test "normalizes the pending email" do
+    user = users(:one)
+    sign_in_as user
+
+    patch users_email_path, params: {
+      current_password: "password",
+      user: { unconfirmed_email: "  NEW@Example.com  " }
+    }
+
+    assert_equal "new@example.com", user.reload.unconfirmed_email
+  end
+
+  test "a user with a password must supply the correct current password" do
+    user = users(:one)
+    sign_in_as user
+
+    assert_no_enqueued_emails do
+      patch users_email_path, params: {
+        current_password: "wrong",
+        user: { unconfirmed_email: "new@example.com" }
+      }
+    end
+
+    assert_response :unprocessable_entity
+    assert_nil user.reload.unconfirmed_email
+  end
+
+  test "a passwordless user sets a pending email without a current password" do
+    user = users(:passwordless)
+    sign_in_as user
+
+    assert_enqueued_email_with RegistrationMailer, :email_change, args: [user, organizations(:arlington)] do
+      patch users_email_path, params: {
+        user: { unconfirmed_email: "new@example.com" }
+      }
+    end
+
+    assert_redirected_to users_email_path
+    assert_equal "new@example.com", user.reload.unconfirmed_email
+  end
+
+  test "rejects an invalid email format" do
+    user = users(:one)
+    sign_in_as user
+
+    assert_no_enqueued_emails do
+      patch users_email_path, params: {
+        current_password: "password",
+        user: { unconfirmed_email: "not-an-email" }
+      }
+    end
+
+    assert_response :unprocessable_entity
+    assert_nil user.reload.unconfirmed_email
+  end
+
+  test "rejects the current email address" do
+    user = users(:one)
+    sign_in_as user
+
+    assert_no_enqueued_emails do
+      patch users_email_path, params: {
+        current_password: "password",
+        user: { unconfirmed_email: "one@example.com" }
+      }
+    end
+
+    assert_response :unprocessable_entity
+    assert_nil user.reload.unconfirmed_email
+  end
+
+  test "rejects an email already taken by another user" do
+    user = users(:one)
+    sign_in_as user
+
+    assert_no_enqueued_emails do
+      patch users_email_path, params: {
+        current_password: "password",
+        user: { unconfirmed_email: users(:two).email_address }
+      }
+    end
+
+    assert_response :unprocessable_entity
+    assert_nil user.reload.unconfirmed_email
+  end
+
+  test "resubmitting overwrites a prior pending email" do
+    user = users(:one)
+    user.update!(unconfirmed_email: "first@example.com")
+    sign_in_as user
+
+    patch users_email_path, params: {
+      current_password: "password",
+      user: { unconfirmed_email: "second@example.com" }
+    }
+
+    assert_equal "second@example.com", user.reload.unconfirmed_email
+  end
+
+  test "confirm swaps the email and does not create a session" do
+    user = users(:one)
+    user.update!(unconfirmed_email: "new@example.com")
+    token = user.generate_token_for(:email_change)
+
+    get confirm_users_email_path(token: token)
+
+    assert_redirected_to new_session_path
+    user.reload
+    assert_equal "new@example.com", user.email_address
+    assert_nil user.unconfirmed_email
+    assert_nil cookies[:session_id]
+  end
+
+  test "confirm with an invalid token leaves the email unchanged" do
+    user = users(:one)
+    user.update!(unconfirmed_email: "new@example.com")
+
+    get confirm_users_email_path(token: "bogus")
+
+    assert_redirected_to new_session_path
+    user.reload
+    assert_equal "one@example.com", user.email_address
+    assert_equal "new@example.com", user.unconfirmed_email
+  end
+
+  test "confirm with a stale token (pending email replaced) is rejected" do
+    user = users(:one)
+    user.update!(unconfirmed_email: "new@example.com")
+    token = user.generate_token_for(:email_change)
+
+    # Replace the pending email, invalidating the token generated above.
+    user.update!(unconfirmed_email: "other@example.com")
+
+    get confirm_users_email_path(token: token)
+
+    assert_redirected_to new_session_path
+    assert_equal "one@example.com", user.reload.email_address
+  end
+
+  test "confirm fails gracefully when the email was taken in the meantime" do
+    user = users(:one)
+    user.update!(unconfirmed_email: "taken@example.com")
+    token = user.generate_token_for(:email_change)
+
+    User.create!(email_address: "taken@example.com", confirmed_at: Time.current)
+
+    get confirm_users_email_path(token: token)
+
+    assert_redirected_to new_session_path
+    user.reload
+    assert_equal "one@example.com", user.email_address
+    assert_nil user.unconfirmed_email
+  end
+end

--- a/test/mailers/previews/registration_mailer_preview.rb
+++ b/test/mailers/previews/registration_mailer_preview.rb
@@ -4,4 +4,11 @@ class RegistrationMailerPreview < ActionMailer::Preview
   def confirmation
     RegistrationMailer.confirmation(User.take, Organization.take)
   end
+
+  # Preview this email at http://localhost:3000/rails/mailers/registration_mailer/email_change
+  def email_change
+    user = User.take
+    user.unconfirmed_email = "new-address@example.com"
+    RegistrationMailer.email_change(user, Organization.take)
+  end
 end


### PR DESCRIPTION
Adds a self-service email change at `/users/email`. Since email is the login identifier, the new address is stored as a pending `unconfirmed_email` and only takes effect after the user clicks a confirmation link sent to the new address — the old email stays active until then to prevent lockout from typos. Initiating a change requires the current password when the user has one (passwordless magic-link users skip it), and the confirm step re-checks uniqueness for the TOCTOU window without auto-creating a session. Includes a new migration/column, an `email_change` mailer and templates, a settings page with cross-links to the password page, and a mailer preview. Covered by 14 integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)