### PR TITLE
Show "Add amount" affordance when total giving amount is blank

### DIFF
--- a/app/views/scenarios/total_giving_amounts/_total_giving_amount.html.erb
+++ b/app/views/scenarios/total_giving_amounts/_total_giving_amount.html.erb
@@ -2,13 +2,23 @@
   <div class="rounded-2xl border border-line bg-surface p-6 shadow-sm">
     <div class="flex items-center gap-4">
       <span class="w-40 text-ink-soft">Total giving amount</span>
-      <%= link_to edit_scenario_total_giving_amount_path(scenario), class: "group inline-flex items-center gap-2" do %>
-        <span class="font-medium text-ink"><%= number_to_currency(scenario.total_giving_amount, precision: 0) %></span>
-        <span class="text-ink-faint opacity-0 transition group-hover:opacity-100" aria-hidden="true">
-          <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931z" />
+      <% if scenario.total_giving_amount.present? %>
+        <%= link_to edit_scenario_total_giving_amount_path(scenario), class: "group inline-flex items-center gap-2" do %>
+          <span class="font-medium text-ink"><%= number_to_currency(scenario.total_giving_amount, precision: 0) %></span>
+          <span class="text-ink-faint opacity-0 transition group-hover:opacity-100" aria-hidden="true">
+            <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931z" />
+            </svg>
+          </span>
+        <% end %>
+      <% else %>
+        <%= link_to edit_scenario_total_giving_amount_path(scenario),
+              class: "inline-flex items-center gap-1.5 rounded-md border border-dashed border-line px-2.5 py-1 text-ink-soft transition hover:border-accent hover:text-accent cursor-pointer" do %>
+          <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
           </svg>
-        </span>
+          <span class="font-medium">Add amount</span>
+        <% end %>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
When a scenario had no total giving amount, the display partial rendered an empty currency span with a hover-only pencil icon, so the clickable edit area was effectively invisible. This branches the display partial on `total_giving_amount.present?` and renders a clearly clickable, always-visible dashed-border "Add amount" button in the empty state. The existing populated state and Turbo Frame edit-in-place flow are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)