### PR TITLE
Add super admin users with owner access to all organizations

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,7 +35,8 @@ class User < ApplicationRecord
   validates :password, confirmation: true, allow_blank: true
 
   def member_of?(organization)
-    organization && organizations.exists?(organization.id)
+    return false unless organization
+    super_admin? || organizations.exists?(organization.id)
   end
 
   def membership_in(organization)
@@ -43,11 +44,17 @@ class User < ApplicationRecord
   end
 
   def admin_of?(organization)
+    return false unless organization
+    return true if super_admin?
+
     membership = membership_in(organization)
     membership&.admin? || membership&.owner?
   end
 
   def owner_of?(organization)
+    return false unless organization
+    return true if super_admin?
+
     membership_in(organization)&.owner?
   end
 

--- a/db/migrate/20260622030000_add_super_admin_to_users.rb
+++ b/db/migrate/20260622030000_add_super_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddSuperAdminToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :super_admin, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_22_021652) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_22_030000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -98,6 +98,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_22_021652) do
     t.datetime "updated_at", null: false
     t.datetime "confirmed_at"
     t.string "unconfirmed_email"
+    t.boolean "super_admin", default: false, null: false
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end
 

--- a/test/controllers/organizations_controller_test.rb
+++ b/test/controllers/organizations_controller_test.rb
@@ -52,4 +52,19 @@ class OrganizationsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_path
     assert_not_equal "Hijacked", @organization.reload.name
   end
+
+  # super admins act as owners on any org they don't belong to
+
+  test "a super admin can view the edit form for an org they don't belong to" do
+    sign_in_as(users(:super_admin))
+    get edit_organization_path
+    assert_response :success
+  end
+
+  test "a super admin can update an org they don't belong to" do
+    sign_in_as(users(:super_admin))
+    patch organization_path, params: { organization: { name: "Renamed by super admin" } }
+    assert_redirected_to edit_organization_path
+    assert_equal "Renamed by super admin", @organization.reload.name
+  end
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -24,3 +24,10 @@ admin:
 passwordless:
   email_address: passwordless@example.com
   confirmed_at: <%= Time.current.to_fs(:db) %>
+
+# Super admin who belongs to no organization — virtual owner of every org.
+super_admin:
+  email_address: super_admin@example.com
+  password_digest: <%= password_digest %>
+  confirmed_at: <%= Time.current.to_fs(:db) %>
+  super_admin: true

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -33,6 +33,24 @@ class UserTest < ActiveSupport::TestCase
     assert_not users(:two).owner_of?(arlington)    # non-member
   end
 
+  test "super admins are virtual owners of every organization without a membership" do
+    super_admin = users(:super_admin)
+    arlington = organizations(:arlington)
+
+    assert_empty super_admin.organizations # no membership rows
+    assert super_admin.member_of?(arlington)
+    assert super_admin.admin_of?(arlington)
+    assert super_admin.owner_of?(arlington)
+    assert super_admin.member_of?(organizations(:boston))
+  end
+
+  test "super admin checks still reject a nil organization" do
+    super_admin = users(:super_admin)
+    assert_not super_admin.member_of?(nil)
+    assert_not super_admin.admin_of?(nil)
+    assert_not super_admin.owner_of?(nil)
+  end
+
   test "is valid without a password" do
     user = User.new(email_address: "passwordless@example.org")
     assert user.valid?


### PR DESCRIPTION
Adds a `super_admin` boolean flag to users, granting cross-organization access where they act as a virtual owner of every organization without needing an `organization_memberships` row. The `member_of?`, `admin_of?`, and `owner_of?` checks on `User` short-circuit to `true` for super admins, so existing tenant-access and owner/admin guards inherit the behavior with no controller changes. Super admin is granted via console/seeds only — there is no management UI. Includes a migration, model/controller tests, and a `super_admin` fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)