### PR TITLE
Add line-level code coverage gate with SimpleCov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,9 +89,17 @@ jobs:
       - name: Run tests
         env:
           RAILS_ENV: test
+          # Generate the SimpleCov report; the threshold is checked in the next step.
+          COVERAGE: "1"
           # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
           # REDIS_URL: redis://localhost:6379/0
         run: bin/rails db:test:prepare test
+
+      - name: Check coverage threshold
+        # COVERAGE_MINIMUM_LINE is the tracked baseline (kept in sync with config/ci.rb).
+        env:
+          COVERAGE_MINIMUM_LINE: "90"
+        run: ruby script/check_coverage.rb
 
   system-test:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@
 # Ignore personal local Claude instructions.
 /CLAUDE.local.md
 
+# SimpleCov code coverage reports
+/coverage
+

--- a/Gemfile
+++ b/Gemfile
@@ -76,4 +76,7 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
+
+  # Code coverage; started in test/test_helper.rb only when COVERAGE=1
+  gem "simplecov", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,6 +138,7 @@ GEM
     debug (1.11.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    docile (1.4.1)
     dotenv (3.2.0)
     drb (2.2.3)
     ed25519 (1.4.0)
@@ -344,6 +345,12 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.2)
+    simplecov_json_formatter (0.1.4)
     solid_cable (4.0.0)
       actioncable (>= 7.2)
       activejob (>= 7.2)
@@ -447,6 +454,7 @@ DEPENDENCIES
   reactionview
   rubocop-rails-omakase
   selenium-webdriver
+  simplecov
   solid_cable
   solid_cache
   solid_queue
@@ -490,6 +498,7 @@ CHECKSUMS
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
+  docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
   dotenv (3.2.0) sha256=e375b83121ea7ca4ce20f214740076129ab8514cd81378161f11c03853fe619d
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   ed25519 (1.4.0) sha256=16e97f5198689a154247169f3453ef4cfd3f7a47481fde0ae33206cdfdcac506
@@ -587,6 +596,9 @@ CHECKSUMS
   rubyzip (3.3.1) sha256=2ed92112c7c43ba2b2527f35e6d99d9c2c99270b640aad5227516436481b1e4e
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   selenium-webdriver (4.44.0) sha256=6f1df072529af369589c46f0e01132952aabb250cfd683c274d74dc1eb5d8477
+  simplecov (0.22.0) sha256=fe2622c7834ff23b98066bb0a854284b2729a569ac659f82621fc22ef36213a5
+  simplecov-html (0.13.2) sha256=bd0b8e54e7c2d7685927e8d6286466359b6f16b18cb0df47b508e8d73c777246
+  simplecov_json_formatter (0.1.4) sha256=529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428
   solid_cable (4.0.0) sha256=8379680ef6bf36e195eb876a6306ea290f87d5fa10bc4a757bc2a918f83229b5
   solid_cache (1.0.10) sha256=bc05a2fb3ac78a6f43cbb5946679cf9db67dd30d22939ededc385cb93e120d41
   solid_queue (1.4.0) sha256=e6a18d196f0b27cb6e3c77c5b31258b05fb634f8ed64fb1866ed164047216c2a

--- a/config/ci.rb
+++ b/config/ci.rb
@@ -8,7 +8,12 @@ CI.run do
   step "Security: Gem audit", "bin/bundler-audit"
   step "Security: Importmap vulnerability audit", "bin/importmap audit"
   step "Security: Brakeman code analysis", "bin/brakeman --quiet --no-pager --exit-on-warn --exit-on-error"
-  step "Tests: Rails", "bin/rails test"
+  # Start from a clean, fixture-ready test DB. Coverage runs serially against the
+  # shared test DB (see test/test_helper.rb), so reset it first.
+  step "Tests: Reset test DB", "env RAILS_ENV=test bin/rails db:test:prepare"
+  step "Tests: Rails", "env COVERAGE=1 bin/rails test"
+  # COVERAGE_MINIMUM_LINE is the tracked baseline; fails if line coverage drops below it.
+  step "Coverage: Line >= 90%", "env COVERAGE_MINIMUM_LINE=90 ruby script/check_coverage.rb"
   step "Tests: Seeds", "env RAILS_ENV=test bin/rails db:seed:replant"
 
   # Optional: Run system tests

--- a/script/check_coverage.rb
+++ b/script/check_coverage.rb
@@ -1,0 +1,23 @@
+#!/usr/bin/env ruby
+# Fails (non-zero exit) if the last SimpleCov run's line coverage is below
+# COVERAGE_MINIMUM_LINE. Run after `COVERAGE=1 bin/rails test`. SimpleCov's
+# inline minimum_coverage prints a warning but doesn't fail `bin/rails test`,
+# so the CI gate lives here instead.
+
+require "json"
+
+minimum = Float(ENV.fetch("COVERAGE_MINIMUM_LINE", "0"))
+last_run = File.expand_path("../coverage/.last_run.json", __dir__)
+
+unless File.exist?(last_run)
+  abort "Coverage summary not found at #{last_run}. Run tests with COVERAGE=1 first."
+end
+
+covered = JSON.parse(File.read(last_run)).dig("result", "line")
+abort "Could not read line coverage from #{last_run}." unless covered
+
+if covered < minimum
+  abort format("Line coverage %.2f%% is below the required minimum %.2f%%.", covered, minimum)
+end
+
+puts format("Line coverage %.2f%% meets the required minimum %.2f%%.", covered, minimum)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,15 @@
 ENV["RAILS_ENV"] ||= "test"
 
+# The minimum-coverage gate is enforced separately by script/check_coverage.rb
+# (SimpleCov's inline minimum_coverage doesn't propagate a non-zero exit through
+# `bin/rails test`). Here we only generate the report.
+if ENV["COVERAGE"] == "1"
+  require "simplecov"
+  SimpleCov.start "rails" do
+    command_name ENV.fetch("SIMPLECOV_COMMAND_NAME", "rails-tests")
+  end
+end
+
 # Hash passwords at bcrypt's minimum cost in tests to improve test speed.
 require "bcrypt"
 BCrypt::Engine.cost = BCrypt::Engine::MIN_COST
@@ -10,8 +20,9 @@ require_relative "test_helpers/session_test_helper"
 
 module ActiveSupport
   class TestCase
-    # Run tests in parallel with specified workers
-    parallelize(workers: :number_of_processors)
+    # Run tests in parallel with specified workers. Under coverage, run serially
+    # so SimpleCov's resultset isn't fragmented across forked workers.
+    parallelize(workers: ENV["COVERAGE"] == "1" ? 1 : :number_of_processors)
 
     # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
     fixtures :all


### PR DESCRIPTION
Adds SimpleCov to measure line coverage, started only when `COVERAGE=1` so normal `bin/rails test` runs stay fast and parallel. A standalone `script/check_coverage.rb` enforces a minimum line-coverage threshold, since SimpleCov's inline `minimum_coverage` only warns and doesn't fail the run. The gate runs in both `bin/ci` and the GitHub Actions test job, with the baseline set to 90% (current coverage is 90.09%). Under coverage the suite runs serially so forked parallel workers don't fragment the resultset, and `/coverage` is gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)