### PR TITLE
Restyle transactional emails with shared Postmark layout

### DIFF
--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -1,13 +1,345 @@
-<!DOCTYPE html>
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
   <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <style>
-      /* Email styles need to be inline */
-    </style>
-  </head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="x-apple-disable-message-reformatting" />
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta name="color-scheme" content="light dark" />
+    <meta name="supported-color-schemes" content="light dark" />
+    <title></title>
+    <style type="text/css" rel="stylesheet" media="all">
+    /* Base ------------------------------ */
 
+    @import url("https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;500;600&display=swap");
+    body {
+      width: 100% !important;
+      height: 100%;
+      margin: 0;
+      -webkit-text-size-adjust: none;
+    }
+
+    a {
+      color: #E07B39;
+    }
+
+    a img {
+      border: none;
+    }
+
+    td {
+      word-break: break-word;
+    }
+
+    .preheader {
+      display: none !important;
+      visibility: hidden;
+      mso-hide: all;
+      font-size: 1px;
+      line-height: 1px;
+      max-height: 0;
+      max-width: 0;
+      opacity: 0;
+      overflow: hidden;
+    }
+    /* Type ------------------------------ */
+
+    body,
+    td,
+    th {
+      font-family: "DM Sans", Helvetica, Arial, sans-serif;
+    }
+
+    h1 {
+      margin-top: 0;
+      color: #1A1814;
+      font-size: 22px;
+      font-weight: bold;
+      text-align: left;
+    }
+
+    h2 {
+      margin-top: 0;
+      color: #1A1814;
+      font-size: 16px;
+      font-weight: bold;
+      text-align: left;
+    }
+
+    h3 {
+      margin-top: 0;
+      color: #1A1814;
+      font-size: 14px;
+      font-weight: bold;
+      text-align: left;
+    }
+
+    td,
+    th {
+      font-size: 16px;
+    }
+
+    p,
+    ul,
+    ol,
+    blockquote {
+      margin: .4em 0 1.1875em;
+      font-size: 16px;
+      line-height: 1.625;
+    }
+
+    p.sub {
+      font-size: 13px;
+    }
+    /* Utilities ------------------------------ */
+
+    .align-right {
+      text-align: right;
+    }
+
+    .align-left {
+      text-align: left;
+    }
+
+    .align-center {
+      text-align: center;
+    }
+
+    .u-margin-bottom-none {
+      margin-bottom: 0;
+    }
+    /* Buttons ------------------------------ */
+
+    .button {
+      background-color: #E07B39;
+      border-top: 10px solid #E07B39;
+      border-right: 18px solid #E07B39;
+      border-bottom: 10px solid #E07B39;
+      border-left: 18px solid #E07B39;
+      display: inline-block;
+      color: #FFF;
+      text-decoration: none;
+      border-radius: 3px;
+      box-shadow: 0 2px 3px rgba(0, 0, 0, 0.16);
+      -webkit-text-size-adjust: none;
+      box-sizing: border-box;
+    }
+
+    @media only screen and (max-width: 500px) {
+      .button {
+        width: 100% !important;
+        text-align: center !important;
+      }
+    }
+    /* Attribute list ------------------------------ */
+
+    .attributes {
+      margin: 0 0 21px;
+    }
+
+    .attributes_content {
+      background-color: #F4F4F7;
+      padding: 16px;
+    }
+
+    .attributes_item {
+      padding: 0;
+    }
+
+    body {
+      background-color: #F5F2ED;
+      color: #51545E;
+    }
+
+    p {
+      color: #51545E;
+    }
+
+    .email-wrapper {
+      width: 100%;
+      margin: 0;
+      padding: 0;
+      -premailer-width: 100%;
+      -premailer-cellpadding: 0;
+      -premailer-cellspacing: 0;
+      background-color: #F5F2ED;
+    }
+
+    .email-content {
+      width: 100%;
+      margin: 0;
+      padding: 0;
+      -premailer-width: 100%;
+      -premailer-cellpadding: 0;
+      -premailer-cellspacing: 0;
+    }
+    /* Masthead ----------------------- */
+
+    .email-masthead {
+      padding: 25px 0;
+      text-align: center;
+    }
+
+    .email-masthead_name {
+      font-size: 16px;
+      font-weight: bold;
+      color: #6E6960;
+      text-decoration: none;
+      text-shadow: 0 1px 0 white;
+    }
+    /* Body ------------------------------ */
+
+    .email-body {
+      width: 100%;
+      margin: 0;
+      padding: 0;
+      -premailer-width: 100%;
+      -premailer-cellpadding: 0;
+      -premailer-cellspacing: 0;
+    }
+
+    .email-body_inner {
+      width: 570px;
+      margin: 0 auto;
+      padding: 0;
+      -premailer-width: 570px;
+      -premailer-cellpadding: 0;
+      -premailer-cellspacing: 0;
+      background-color: #FFFFFF;
+    }
+
+    .email-footer {
+      width: 570px;
+      margin: 0 auto;
+      padding: 0;
+      -premailer-width: 570px;
+      -premailer-cellpadding: 0;
+      -premailer-cellspacing: 0;
+      text-align: center;
+    }
+
+    .email-footer p {
+      color: #A8AAAF;
+    }
+
+    .body-action {
+      width: 100%;
+      margin: 30px auto;
+      padding: 0;
+      -premailer-width: 100%;
+      -premailer-cellpadding: 0;
+      -premailer-cellspacing: 0;
+      text-align: center;
+    }
+
+    .body-sub {
+      margin-top: 25px;
+      padding-top: 25px;
+      border-top: 1px solid #EAEAEC;
+    }
+
+    .content-cell {
+      padding: 45px;
+    }
+    /*Media Queries ------------------------------ */
+
+    @media only screen and (max-width: 600px) {
+      .email-body_inner,
+      .email-footer {
+        width: 100% !important;
+      }
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body,
+      .email-body,
+      .email-body_inner,
+      .email-content,
+      .email-wrapper,
+      .email-masthead,
+      .email-footer {
+        background-color: #333333 !important;
+        color: #FFF !important;
+      }
+      p,
+      ul,
+      ol,
+      blockquote,
+      h1,
+      h2,
+      h3,
+      span {
+        color: #FFF !important;
+      }
+      .attributes_content {
+        background-color: #222 !important;
+      }
+      .email-masthead_name {
+        text-shadow: none !important;
+      }
+    }
+
+    :root {
+      color-scheme: light dark;
+      supported-color-schemes: light dark;
+    }
+    </style>
+    <!--[if mso]>
+    <style type="text/css">
+      .f-fallback  {
+        font-family: Arial, sans-serif;
+      }
+    </style>
+  <![endif]-->
+  </head>
   <body>
-    <%= yield %>
+    <% if content_for?(:preheader) %>
+      <span class="preheader"><%= yield :preheader %></span>
+    <% end %>
+    <table class="email-wrapper" width="100%" cellpadding="0" cellspacing="0" role="presentation">
+      <tr>
+        <td align="center">
+          <table class="email-content" width="100%" cellpadding="0" cellspacing="0" role="presentation">
+            <tr>
+              <td class="email-masthead">
+                <% if @organization&.website.present? %>
+                  <a href="<%= @organization.website %>" class="f-fallback email-masthead_name"><%= @organization.name %></a>
+                <% else %>
+                  <span class="f-fallback email-masthead_name"><%= @organization&.name %></span>
+                <% end %>
+              </td>
+            </tr>
+            <!-- Email Body -->
+            <tr>
+              <td class="email-body" width="570" cellpadding="0" cellspacing="0">
+                <table class="email-body_inner" align="center" width="570" cellpadding="0" cellspacing="0" role="presentation">
+                  <!-- Body content -->
+                  <tr>
+                    <td class="content-cell">
+                      <div class="f-fallback">
+                        <%= yield %>
+                      </div>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <table class="email-footer" align="center" width="570" cellpadding="0" cellspacing="0" role="presentation">
+                  <tr>
+                    <td class="content-cell" align="center">
+                      <p class="f-fallback sub align-center">
+                        <%= @organization&.name %>
+                        <br>Powered by Community Foundations
+                      </p>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
   </body>
 </html>

--- a/app/views/layouts/mailer.text.erb
+++ b/app/views/layouts/mailer.text.erb
@@ -1,1 +1,7 @@
+<%= @organization&.name %>
+
 <%= yield %>
+
+--
+<%= @organization&.name %>
+Powered by Community Foundations

--- a/app/views/magic_link_mailer/sign_in_link.html.erb
+++ b/app/views/magic_link_mailer/sign_in_link.html.erb
@@ -1,6 +1,7 @@
-<p>
-  Sign in by visiting
-  <%= link_to "this sign-in page", magic_link_url(token: @user.generate_token_for(:magic_link), subdomain: @organization.subdomain) %>.
-
-  This link will expire in 30 minutes.
-</p>
+<% content_for :preheader, "Use this link to sign in. It expires in 30 minutes." %>
+<h1>Sign in to <%= @organization.name %></h1>
+<p>Use the button below to sign in to your account. <strong>This link is only valid for the next 30 minutes.</strong></p>
+<%= render "shared/email_button",
+      url: magic_link_url(token: @user.generate_token_for(:magic_link), subdomain: @organization.subdomain),
+      label: "Sign in" %>
+<p>If you didn't request this sign-in link, you can safely ignore this email.</p>

--- a/app/views/magic_link_mailer/sign_in_link.text.erb
+++ b/app/views/magic_link_mailer/sign_in_link.text.erb
@@ -1,4 +1,7 @@
-Sign in by visiting
+Sign in to <%= @organization.name %>
+
+Use the link below to sign in to your account. This link is only valid for the next 30 minutes.
+
 <%= magic_link_url(token: @user.generate_token_for(:magic_link), subdomain: @organization.subdomain) %>
 
-This link will expire in 30 minutes.
+If you didn't request this sign-in link, you can safely ignore this email.

--- a/app/views/passwords_mailer/reset.html.erb
+++ b/app/views/passwords_mailer/reset.html.erb
@@ -1,6 +1,7 @@
-<p>
-  You can reset your password on
-  <%= link_to "this password reset page", edit_password_url(@user.password_reset_token, subdomain: @organization.subdomain) %>.
-
-  This link will expire in <%= distance_of_time_in_words(0, @user.password_reset_token_expires_in) %>.
-</p>
+<% content_for :preheader, "Use this link to reset your password." %>
+<h1>Reset your password</h1>
+<p>You recently requested to reset your password. Use the button below to choose a new one. <strong>This link is only valid for the next <%= distance_of_time_in_words(0, @user.password_reset_token_expires_in) %>.</strong></p>
+<%= render "shared/email_button",
+      url: edit_password_url(@user.password_reset_token, subdomain: @organization.subdomain),
+      label: "Reset password" %>
+<p>If you didn't request a password reset, you can safely ignore this email.</p>

--- a/app/views/passwords_mailer/reset.text.erb
+++ b/app/views/passwords_mailer/reset.text.erb
@@ -1,4 +1,7 @@
-You can reset your password on
+Reset your password
+
+You recently requested to reset your password. Use the link below to choose a new one. This link is only valid for the next <%= distance_of_time_in_words(0, @user.password_reset_token_expires_in) %>.
+
 <%= edit_password_url(@user.password_reset_token, subdomain: @organization.subdomain) %>
 
-This link will expire in <%= distance_of_time_in_words(0, @user.password_reset_token_expires_in) %>.
+If you didn't request a password reset, you can safely ignore this email.

--- a/app/views/registration_mailer/confirmation.html.erb
+++ b/app/views/registration_mailer/confirmation.html.erb
@@ -1,6 +1,7 @@
-<p>
-  Welcome! Please confirm your email address by visiting
-  <%= link_to "this confirmation page", email_confirmation_url(token: @user.generate_token_for(:email_confirmation), subdomain: @organization.subdomain) %>.
-
-  This link will expire in 24 hours.
-</p>
+<% content_for :preheader, "Confirm your email address to finish setting up your account." %>
+<h1>Confirm your email</h1>
+<p>Welcome! Please confirm your email address using the button below to finish setting up your account. <strong>This link is only valid for the next 24 hours.</strong></p>
+<%= render "shared/email_button",
+      url: email_confirmation_url(token: @user.generate_token_for(:email_confirmation), subdomain: @organization.subdomain),
+      label: "Confirm email address" %>
+<p>If you didn't create this account, you can safely ignore this email.</p>

--- a/app/views/registration_mailer/confirmation.text.erb
+++ b/app/views/registration_mailer/confirmation.text.erb
@@ -1,4 +1,7 @@
-Welcome! Please confirm your email address by visiting
+Confirm your email
+
+Welcome! Please confirm your email address using the link below to finish setting up your account. This link is only valid for the next 24 hours.
+
 <%= email_confirmation_url(token: @user.generate_token_for(:email_confirmation), subdomain: @organization.subdomain) %>
 
-This link will expire in 24 hours.
+If you didn't create this account, you can safely ignore this email.

--- a/app/views/registration_mailer/email_change.html.erb
+++ b/app/views/registration_mailer/email_change.html.erb
@@ -1,6 +1,7 @@
-<p>
-  Confirm your new email address by visiting
-  <%= link_to "this confirmation page", confirm_users_email_url(token: @user.generate_token_for(:email_change), subdomain: @organization.subdomain) %>.
-
-  This link will expire in 24 hours. If you didn't request this change, you can ignore this email.
-</p>
+<% content_for :preheader, "Confirm your new email address. This link expires in 24 hours." %>
+<h1>Confirm your new email address</h1>
+<p>Use the button below to confirm your new email address. <strong>This link is only valid for the next 24 hours.</strong></p>
+<%= render "shared/email_button",
+      url: confirm_users_email_url(token: @user.generate_token_for(:email_change), subdomain: @organization.subdomain),
+      label: "Confirm new email" %>
+<p>If you didn't request this change, you can safely ignore this email.</p>

--- a/app/views/registration_mailer/email_change.text.erb
+++ b/app/views/registration_mailer/email_change.text.erb
@@ -1,4 +1,7 @@
-Confirm your new email address by visiting
+Confirm your new email address
+
+Use the link below to confirm your new email address. This link is only valid for the next 24 hours.
+
 <%= confirm_users_email_url(token: @user.generate_token_for(:email_change), subdomain: @organization.subdomain) %>
 
-This link will expire in 24 hours. If you didn't request this change, you can ignore this email.
+If you didn't request this change, you can safely ignore this email.

--- a/app/views/shared/_email_button.html.erb
+++ b/app/views/shared/_email_button.html.erb
@@ -1,0 +1,24 @@
+<%# locals: (url:, label:) %>
+<table class="body-action" align="center" width="100%" cellpadding="0" cellspacing="0" role="presentation">
+  <tr>
+    <td align="center">
+      <!-- Border based button
+           https://litmus.com/blog/a-guide-to-bulletproof-buttons-in-email-design -->
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" role="presentation">
+        <tr>
+          <td align="center">
+            <a href="<%= url %>" class="f-fallback button" target="_blank" rel="noopener"><%= label %></a>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
+<table class="body-sub" role="presentation">
+  <tr>
+    <td>
+      <p class="f-fallback sub">If you're having trouble with the button above, copy and paste the URL below into your web browser.</p>
+      <p class="f-fallback sub"><%= url %></p>
+    </td>
+  </tr>
+</table>


### PR DESCRIPTION
Restyles the four transactional emails (magic-link sign-in, signup confirmation, email-change confirmation, password reset) using ActiveCampaign's open-source Postmark "basic" template, rebranded to Community Foundations (DM Sans, orange #E07B39 buttons/links, beige canvas). All shared markup — masthead, footer, fonts, and styling — now lives in the `mailer` layout, so any new email inherits the format automatically. A reusable `shared/_email_button` partial provides a bulletproof CTA button with a copy/paste-URL fallback. Both HTML and plain-text parts were updated; URL helpers, tokens, and expiry logic are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)