### PR TITLE
Add "Explore options" link to nav bar for logged-in users

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -41,6 +41,7 @@
           <%= link_to "Mailer previews", "/rails/mailers", class: "text-ink-soft hover:text-ink" %>
         <% end %>
         <% if authenticated? %>
+          <%= link_to "Explore options", scenarios_path, class: "text-ink-soft hover:text-ink" %>
           <% if Current.user&.admin_of?(Current.organization) %>
             <%= link_to "Members", organization_memberships_path, class: "text-ink-soft hover:text-ink" %>
           <% end %>


### PR DESCRIPTION
Adds an "Explore options" link to the authenticated section of the nav bar. It points to `scenarios_path` — the same destination as the home page hero's "Explore options" CTA — giving logged-in users a persistent way back to the scenarios list from anywhere in the app. The link uses the existing `text-ink-soft hover:text-ink` nav styling and matches the app's existing label casing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)