### PR TITLE
Add admin scenarios dashboard for owners and admins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,9 @@ group :development, :test do
 
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false
+
+  # Generate realistic fake data for development/test seeds [https://github.com/faker-ruby/faker]
+  gem "faker"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,8 @@ GEM
     erubi (1.13.1)
     et-orbi (1.4.0)
       tzinfo
+    faker (3.8.0)
+      i18n (>= 1.8.11, < 2)
     ffi (1.17.4-aarch64-linux-gnu)
     ffi (1.17.4-aarch64-linux-musl)
     ffi (1.17.4-arm-linux-gnu)
@@ -441,6 +443,7 @@ DEPENDENCIES
   bundler-audit
   capybara
   debug
+  faker
   image_processing (~> 1.2)
   importmap-rails
   jbuilder
@@ -505,6 +508,7 @@ CHECKSUMS
   erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
   et-orbi (1.4.0) sha256=6c7e3c90779821f9e3b324c5e96fda9767f72995d6ae435b96678a4f3e2de8bc
+  faker (3.8.0) sha256=c147b308df73a90f27a4fc84f18d4c22ef0ad9c2a64b2b61c86fd0ca71753efc
   ffi (1.17.4-aarch64-linux-gnu) sha256=b208f06f91ffd8f5e1193da3cae3d2ccfc27fc36fba577baf698d26d91c080df
   ffi (1.17.4-aarch64-linux-musl) sha256=9286b7a615f2676245283aef0a0a3b475ae3aae2bb5448baace630bb77b91f39
   ffi (1.17.4-arm-linux-gnu) sha256=d6dbddf7cb77bf955411af5f187a65b8cd378cb003c15c05697f5feee1cb1564

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -1,0 +1,10 @@
+class Admin::ApplicationController < ApplicationController
+  before_action :require_admin
+
+  private
+
+  def require_admin
+    redirect_to root_path, alert: "You don't have access to that." unless
+      Current.user.admin_of?(Current.organization)
+  end
+end

--- a/app/controllers/admin/scenarios_controller.rb
+++ b/app/controllers/admin/scenarios_controller.rb
@@ -1,0 +1,23 @@
+class Admin::ScenariosController < Admin::ApplicationController
+  PER_PAGE = 50
+
+  def index
+    @query = params[:q].to_s.strip
+    @page = [ params[:page].to_i, 1 ].max
+    @offset = (@page - 1) * PER_PAGE
+
+    scope = Current.organization.scenarios
+                   .includes(:user)
+                   .references(:user)
+                   .order("users.name", "users.email_address", :name)
+
+    if @query.present?
+      like = "%#{Scenario.sanitize_sql_like(@query.downcase)}%"
+      scope = scope.where("LOWER(users.name) LIKE :q OR LOWER(users.email_address) LIKE :q", q: like)
+    end
+
+    @total = scope.count
+    @scenarios = scope.limit(PER_PAGE).offset(@offset)
+    @has_more = @offset + @scenarios.size < @total
+  end
+end

--- a/app/javascript/controllers/debounced_form_controller.js
+++ b/app/javascript/controllers/debounced_form_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = { delay: { type: Number, default: 500 } }
+
+  submit() {
+    clearTimeout(this.timeout)
+    this.timeout = setTimeout(() => this.element.requestSubmit(), this.delayValue)
+  }
+
+  disconnect() {
+    clearTimeout(this.timeout)
+  }
+}

--- a/app/views/admin/scenarios/index.html.erb
+++ b/app/views/admin/scenarios/index.html.erb
@@ -1,0 +1,63 @@
+<% content_for :title, "Scenarios" %>
+
+<div class="mx-auto max-w-6xl w-full px-6 py-10">
+  <div class="flex flex-wrap items-end justify-between gap-4 border-b border-line pb-5">
+    <div>
+      <p class="text-xs font-semibold uppercase tracking-wider text-ink-faint">Admin</p>
+      <h1 class="mt-1 text-2xl font-semibold tracking-tight text-ink">Scenarios</h1>
+    </div>
+    <%= form_with url: admin_scenarios_path, method: :get,
+          data: { controller: "debounced-form", action: "input->debounced-form#submit",
+                  turbo_frame: "scenarios_table", turbo_action: "advance" } do |form| %>
+      <%= form.search_field :q, value: @query,
+            placeholder: "Filter by user…", autocomplete: "off",
+            class: "block w-64 rounded-md border border-line bg-surface px-3 py-1.5 text-sm text-ink placeholder:text-ink-faint focus:border-ink-soft focus:outline-none" %>
+    <% end %>
+  </div>
+
+  <%= turbo_frame_tag "scenarios_table", class: "mt-5 block", data: { turbo_action: "advance" } do %>
+    <div class="overflow-hidden rounded-lg border border-line">
+      <table class="w-full text-left text-sm">
+        <thead class="bg-surface-soft">
+          <tr class="border-b border-line">
+            <th class="px-4 py-2.5 text-xs font-semibold uppercase tracking-wide text-ink-faint">User</th>
+            <th class="px-4 py-2.5 text-xs font-semibold uppercase tracking-wide text-ink-faint">Scenario</th>
+            <th class="px-4 py-2.5 text-right text-xs font-semibold uppercase tracking-wide text-ink-faint">Total giving</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-line-soft">
+          <% @scenarios.each do |scenario| %>
+            <tr class="bg-surface hover:bg-surface-soft transition">
+              <td class="px-4 py-2.5 font-medium text-ink"><%= scenario.user.display_name %></td>
+              <td class="px-4 py-2.5 text-ink-soft"><%= scenario.name %></td>
+              <td class="px-4 py-2.5 text-right tabular-nums text-ink">
+                <%= scenario.total_giving_amount.present? ? number_to_currency(scenario.total_giving_amount, precision: 0) : content_tag(:span, "—", class: "text-ink-faint") %>
+              </td>
+            </tr>
+          <% end %>
+          <% if @total.zero? %>
+            <tr class="bg-surface">
+              <td colspan="3" class="px-4 py-12 text-center text-ink-faint">
+                <%= @query.present? ? "No users match “#{@query}”." : "No scenarios yet." %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+
+    <% if @total.positive? %>
+      <div class="mt-3 flex items-center justify-between text-xs text-ink-soft">
+        <span class="tabular-nums">Showing <%= @offset + 1 %>–<%= @offset + @scenarios.size %> of <%= @total %></span>
+        <div class="flex items-center gap-2">
+          <% if @page > 1 %>
+            <%= link_to "← Prev", admin_scenarios_path(q: @query, page: @page - 1), class: "rounded border border-line px-2.5 py-1 text-ink-soft hover:bg-surface-soft hover:text-ink" %>
+          <% end %>
+          <% if @has_more %>
+            <%= link_to "Next →", admin_scenarios_path(q: @query, page: @page + 1), class: "rounded border border-line px-2.5 py-1 text-ink-soft hover:bg-surface-soft hover:text-ink" %>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,6 +43,7 @@
         <% if authenticated? %>
           <%= link_to "Explore options", scenarios_path, class: "text-ink-soft hover:text-ink" %>
           <% if Current.user&.admin_of?(Current.organization) %>
+            <%= link_to "Admin Dashboard", admin_scenarios_path, class: "text-ink-soft hover:text-ink" %>
             <%= link_to "Members", organization_memberships_path, class: "text-ink-soft hover:text-ink" %>
           <% end %>
           <%= link_to "Profile", users_profile_path, class: "text-ink-soft hover:text-ink" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,11 +19,14 @@ Rails.application.routes.draw do
 
   resource :organization, only: %i[ edit update ]
   resources :organization_memberships, only: %i[ index update ]
-
   resources :scenarios do
     resource :name, only: %i[ show edit update ], module: :scenarios
     resource :total_giving_amount, only: %i[ show edit update ], module: :scenarios
     resources :allocations, only: %i[ create update destroy ]
+  end
+
+  namespace :admin do
+    resources :scenarios, only: :index
   end
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -52,3 +52,32 @@ if education.allocations.empty?
   education.ongoing_allocations.create!(option: "Greatest Community Need", percentage: 15)
   education.one_time_allocations.create!(option: "Scholarship Fund", amount: 500)
 end
+
+scenario_themes = [
+  "Arts & culture", "Climate resilience", "Food security", "Housing first",
+  "Youth mentorship", "Scholarships", "Health access", "Workforce training",
+  "Digital literacy", "Senior services", "Disaster relief", "Refugee support",
+  "Environmental fund", "Clean water", "Mental health", "Crisis hotline",
+  "Community garden", "Neighborhood grants", "Small org boost", "Arts education"
+]
+
+12.times do
+  display_name = Faker::Name.unique.name
+  email = "#{display_name.parameterize}@example.com"
+
+  user = User.find_or_initialize_by(email_address: email)
+  user.name = display_name
+  user.password = "password"
+  user.confirmed_at = Time.current
+  user.save!
+
+  OrganizationMembership.find_or_create_by!(user: user, organization: arlington) do |membership|
+    membership.role = :member
+  end
+
+  scenario_themes.sample(rand(1..3)).each do |name|
+    user.scenarios.find_or_create_by!(organization: arlington, name: name) do |scenario|
+      scenario.total_giving_amount = rand(1..40) * 1_000
+    end
+  end
+end

--- a/test/controllers/admin/scenarios_controller_test.rb
+++ b/test/controllers/admin/scenarios_controller_test.rb
@@ -1,0 +1,66 @@
+require "test_helper"
+
+class Admin::ScenariosControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    host! "arlington.localhost"
+    @owner = users(:one)
+    @admin = users(:admin)
+    @member = users(:passwordless)
+  end
+
+  test "owners and admins can view the dashboard" do
+    sign_in_as(@owner)
+    get admin_scenarios_path
+    assert_response :success
+
+    sign_in_as(@admin)
+    get admin_scenarios_path
+    assert_response :success
+  end
+
+  test "plain members are redirected away from the dashboard" do
+    sign_in_as(@member)
+    get admin_scenarios_path
+    assert_redirected_to root_path
+  end
+
+  test "lists every scenario in the organization with its owner" do
+    sign_in_as(@owner)
+    get admin_scenarios_path
+
+    assert_select "td", text: "Scenario 1"
+    assert_select "td", text: "Admin plan"
+    assert_select "td", text: @owner.display_name
+    assert_select "td", text: @admin.display_name
+  end
+
+  test "does not show scenarios from another organization" do
+    sign_in_as(@owner)
+    get admin_scenarios_path
+
+    assert_select "td", text: "Boston plan", count: 0
+  end
+
+  test "filters scenarios by user name on the server" do
+    sign_in_as(@owner)
+    get admin_scenarios_path(q: "admin")
+
+    assert_select "td", text: "Admin plan"
+    assert_select "td", text: "Scenario 1", count: 0
+  end
+
+  test "paginates results" do
+    sign_in_as(@owner)
+    # Create more scenarios than fit on one page so a second page exists.
+    arlington = organizations(:arlington)
+    (Admin::ScenariosController::PER_PAGE + 5).times do |i|
+      arlington.scenarios.create!(user: @owner, name: "Bulk #{i}")
+    end
+
+    get admin_scenarios_path
+    assert_select "tbody tr", count: Admin::ScenariosController::PER_PAGE
+
+    get admin_scenarios_path(page: 2)
+    assert_select "tbody tr", minimum: 1
+  end
+end

--- a/test/fixtures/scenarios.yml
+++ b/test/fixtures/scenarios.yml
@@ -4,6 +4,12 @@ one_arlington:
   name: Scenario 1
   total_giving_amount: 10000
 
+admin_arlington:
+  user: admin
+  organization: arlington
+  name: Admin plan
+  total_giving_amount: 25000
+
 two_boston:
   user: two
   organization: boston


### PR DESCRIPTION
Adds an admin-only dashboard (`/admin/scenarios`) where organization owners and admins can view every scenario in the org as a table of user, scenario name, and total giving amount. The list is filtered server-side by user name via a debounced Turbo-frame search and paginated (50 per page), so it scales to thousands of scenarios without loading them all client-side. Access is gated through a new `Admin::ApplicationController` base controller (reusing `User#admin_of?`), with a "Admin Dashboard" nav link shown only to admins/owners. A reusable `debounced-form` Stimulus controller powers the search, and `db/seeds.rb` now generates Faker demo members and scenarios to populate the page. Covered by controller tests for access control, server-side filtering, tenant isolation, and pagination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)