### PR TITLE
Add AllocationCategory STI model and category picker for allocations

### DIFF
--- a/.herb.yml
+++ b/.herb.yml
@@ -1,0 +1,106 @@
+# This file configures Herb for your project and team.
+# Settings here take precedence over individual editor preferences.
+#
+# Herb is a suite of tools for HTML+ERB templates including:
+# - Linter: Validates templates and enforces best practices
+# - Formatter: Auto-formats templates with intelligent indentation
+# - Language Server: Provides IDE support (VS Code, Zed, Neovim, etc.)
+#
+# Website: https://herb-tools.dev
+# Configuration: https://herb-tools.dev/configuration
+# GitHub Repo: https://github.com/marcoroth/herb
+#
+
+version: 0.10.1
+
+# Framework and template engine configuration
+# actionview enables the Rails-specific rules, including strict-locals checks.
+framework: actionview
+#
+# # Options: erubi | erb | herb (default: erubi)
+# template_engine: erubi
+
+# files:
+#   # Additional patterns beyond the defaults (**.html, **.rhtml, **.html.erb, etc.)
+#   include:
+#     - '**/*.xml.erb'
+#     - 'custom/**/*.html'
+#
+#   # Patterns to exclude (can exclude defaults too)
+#   exclude:
+#     - 'public/**/*'
+#     - 'tmp/**/*'
+
+# engine:
+#   validators:
+#     security: true       # default: true
+#     nesting: true        # default: true
+#     accessibility: true  # default: true
+
+linter:
+  enabled: true
+
+  # # Exit with error code when diagnostics of this severity or higher are present
+  # # Valid values: error (default), warning, info, hint
+  # failLevel: warning
+
+  # # Additional patterns beyond the defaults for linting
+  # include:
+  #   - '**/*.xml.erb'
+  #
+  # # Patterns to exclude from linting
+  # exclude:
+  #   - 'app/views/admin/**/*'
+
+  rules:
+    # Require every partial to declare its locals with a `<%# locals: (...) %>`
+    # comment. Disabled by default upstream; we opt in to enforce it.
+    erb-strict-locals-required:
+      enabled: true
+
+    # The mailer layout is XHTML 1.0 (Postmark), where self-closing void
+    # elements like `<meta />` are valid and expected.
+    html-no-self-closing:
+      exclude:
+        - 'app/views/layouts/mailer.html.erb'
+
+  #   erb-no-extra-newline:
+  #     enabled: false
+  #
+  #   # Rules can have 'include', 'only', and 'exclude' patterns
+  #   some-rule:
+  #     # Additional patterns to check (additive, ignored when 'only' is present)
+  #     include:
+  #       - 'app/components/**/*'
+  #     # Don't apply this rule to files matching these patterns
+  #     exclude:
+  #       - 'app/views/admin/**/*'
+  #
+  #   another-rule:
+  #     # Only apply this rule to files matching these patterns (overrides all 'include')
+  #     only:
+  #       - 'app/views/**/*'
+  #     # Exclude still applies even with 'only'
+  #     exclude:
+  #       - 'app/views/admin/**/*'
+
+formatter:
+  enabled: false
+  indentWidth: 2
+  maxLineLength: 80
+
+  # # Additional patterns beyond the defaults for formatting
+  # include:
+  #   - '**/*.xml.erb'
+  #
+  # # Patterns to exclude from formatting
+  # exclude:
+  #   - 'app/views/admin/**/*'
+
+  # # Rewriters modify templates during formatting
+  # rewriter:
+  #   # Pre-format rewriters (modify AST before formatting)
+  #   pre:
+  #     - tailwind-class-sorter
+  #   # Post-format rewriters (modify formatted output string)
+  #   post: []

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "marcoroth.herb-lsp"
+  ]
+}

--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -31,6 +31,6 @@ class AllocationsController < ApplicationController
   end
 
   def allocation_params
-    params.require(:allocation).permit(:option, :percentage, :amount, :note, :type)
+    params.require(:allocation).permit(:allocation_category_id, :option, :percentage, :amount, :note, :type)
   end
 end

--- a/app/javascript/controllers/allocation_category_picker_controller.js
+++ b/app/javascript/controllers/allocation_category_picker_controller.js
@@ -1,0 +1,72 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["panel", "search", "row", "tab", "tabPanel", "categoryId", "optionField", "label", "customInput"]
+  static classes = ["activeTab", "inactiveTab"]
+
+  connect() {
+    this.activateInitialTab()
+    document.addEventListener("click", this.onOutsideClick)
+  }
+
+  disconnect() {
+    document.removeEventListener("click", this.onOutsideClick)
+  }
+
+  toggle() {
+    this.panelTarget.hidden = !this.panelTarget.hidden
+  }
+
+  close() {
+    this.panelTarget.hidden = true
+  }
+
+  select(event) {
+    const row = event.currentTarget
+    this.categoryIdTarget.value = row.dataset.id
+    this.optionFieldTarget.value = ""
+    if (this.hasCustomInputTarget) this.customInputTarget.value = ""
+    this.labelTarget.textContent = row.dataset.name
+    this.close()
+  }
+
+  switchTab(event) {
+    this.activateTab(event.currentTarget.dataset.type)
+  }
+
+  filter() {
+    const query = this.searchTarget.value.trim().toLowerCase()
+    this.rowTargets.forEach((row) => {
+      row.hidden = !row.dataset.name.toLowerCase().includes(query)
+    })
+  }
+
+  addCustom() {
+    const value = this.customInputTarget.value.trim()
+    if (!value) return
+    this.optionFieldTarget.value = value
+    this.categoryIdTarget.value = ""
+    this.labelTarget.textContent = value
+    this.close()
+  }
+
+  activateInitialTab() {
+    const active = this.tabTargets.find((tab) => tab.dataset.active === "true") || this.tabTargets[0]
+    if (active) this.activateTab(active.dataset.type)
+  }
+
+  activateTab(type) {
+    this.tabTargets.forEach((tab) => {
+      const on = tab.dataset.type === type
+      tab.classList.add(...(on ? this.activeTabClasses : this.inactiveTabClasses))
+      tab.classList.remove(...(on ? this.inactiveTabClasses : this.activeTabClasses))
+    })
+    this.tabPanelTargets.forEach((panel) => {
+      panel.classList.toggle("hidden", panel.dataset.type !== type)
+    })
+  }
+
+  onOutsideClick = (event) => {
+    if (!this.element.contains(event.target)) this.close()
+  }
+}

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -1,5 +1,18 @@
 class Allocation < ApplicationRecord
   belongs_to :scenario
+  belongs_to :allocation_category, optional: true
 
-  validates :option, presence: true
+  validate :category_or_option_present
+
+  def display_label
+    allocation_category&.name || option
+  end
+
+  private
+
+  def category_or_option_present
+    if allocation_category_id.blank? && option.blank?
+      errors.add(:base, "Choose a category or enter a custom option")
+    end
+  end
 end

--- a/app/models/allocation_category.rb
+++ b/app/models/allocation_category.rb
@@ -1,0 +1,16 @@
+class AllocationCategory < ApplicationRecord
+  belongs_to :organization, class_name: "::Organization"
+  belongs_to :parent, class_name: "AllocationCategory", optional: true
+  has_many :children, class_name: "AllocationCategory", foreign_key: :parent_id, dependent: :destroy
+  has_many :allocations, dependent: :nullify
+
+  validates :name, presence: true
+
+  scope :roots, -> { where(parent_id: nil) }
+
+  TAB_CLASSES = %w[ AllocationCategory::Program AllocationCategory::Population AllocationCategory::Organization ].freeze
+
+  def self.tab_label
+    name.demodulize.titleize
+  end
+end

--- a/app/models/allocation_category/organization.rb
+++ b/app/models/allocation_category/organization.rb
@@ -1,0 +1,2 @@
+class AllocationCategory::Organization < AllocationCategory
+end

--- a/app/models/allocation_category/population.rb
+++ b/app/models/allocation_category/population.rb
@@ -1,0 +1,2 @@
+class AllocationCategory::Population < AllocationCategory
+end

--- a/app/models/allocation_category/program.rb
+++ b/app/models/allocation_category/program.rb
@@ -1,0 +1,2 @@
+class AllocationCategory::Program < AllocationCategory
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -2,6 +2,7 @@ class Organization < ApplicationRecord
   has_many :organization_memberships, dependent: :destroy
   has_many :users, through: :organization_memberships
   has_many :scenarios, dependent: :destroy
+  has_many :allocation_categories, dependent: :destroy
 
   has_one_attached :logo
 

--- a/app/views/home/sections/_contact_button.html.erb
+++ b/app/views/home/sections/_contact_button.html.erb
@@ -1,2 +1,3 @@
+<%# locals: () %>
 <%= link_to "Contact us", Current.organization.website, target: "_blank", rel: "noopener",
       class: "inline-block rounded-md border border-line bg-surface px-6 py-2.5 font-medium text-ink hover:bg-canvas transition" %>

--- a/app/views/home/sections/_faq.html.erb
+++ b/app/views/home/sections/_faq.html.erb
@@ -1,3 +1,4 @@
+<%# locals: () %>
 <% faqs = [
   { q: "What is legacy giving?",
     a: "Legacy giving is a way to support the causes and communities you care about through a planned gift, often as part of your estate or long-term financial plans." },

--- a/app/views/home/sections/_hero.html.erb
+++ b/app/views/home/sections/_hero.html.erb
@@ -1,3 +1,4 @@
+<%# locals: () %>
 <section class="bg-canvas">
   <div class="mx-auto max-w-3xl w-full px-4 py-20 text-center">
     <h1 class="font-serif font-medium text-5xl tracking-tight text-ink">Your Legacy Starts Here</h1>

--- a/app/views/home/sections/_pillars.html.erb
+++ b/app/views/home/sections/_pillars.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (get_started_path:) %>
 <% pillars = [
   { title: "Explore possibilities", body: "Learn about different approaches to legacy giving and the impact they can create." },
   { title: "Reflect on What Matters", body: "Capture ideas, values, and priorities as they evolve over time." },

--- a/app/views/home/sections/_questions.html.erb
+++ b/app/views/home/sections/_questions.html.erb
@@ -1,3 +1,4 @@
+<%# locals: () %>
 <section class="bg-surface border-t border-line-soft">
   <div class="mx-auto max-w-2xl w-full px-4 py-20 text-center">
     <h2 class="font-serif font-medium text-4xl tracking-tight text-ink">Have Questions?</h2>

--- a/app/views/home/sections/_scenario_example.html.erb
+++ b/app/views/home/sections/_scenario_example.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (get_started_path:) %>
 <% segments = [
   { label: "Greatest Community Need", pct: 30, color: "#E07B39" },
   { label: "Program: Education",      pct: 30, color: "#7C3AED" },

--- a/app/views/home/sections/_stories.html.erb
+++ b/app/views/home/sections/_stories.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (get_started_path:) %>
 <section class="bg-surface-soft border-t border-line-soft">
   <div class="mx-auto max-w-5xl w-full px-4 py-20">
     <h2 class="font-serif font-medium text-4xl tracking-tight text-ink">Legacy stories</h2>

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -1,6 +1,6 @@
 <% get_started_path = authenticated? ? scenarios_path : new_registration_path %>
 
-<%= render "home/sections/hero", get_started_path: get_started_path %>
+<%= render "home/sections/hero" %>
 <%= render "home/sections/pillars", get_started_path: get_started_path %>
 <%= render "home/sections/scenario_example", get_started_path: get_started_path %>
 <%= render "home/sections/stories", get_started_path: get_started_path %>

--- a/app/views/scenarios/_allocation.html.erb
+++ b/app/views/scenarios/_allocation.html.erb
@@ -1,7 +1,8 @@
+<%# locals: (allocation:, scenario:) %>
 <div data-controller="dialog">
   <div class="flex items-start justify-between gap-3 rounded-lg border border-line-soft bg-surface px-4 py-3 transition hover:shadow-sm">
     <div class="min-w-0">
-      <p class="font-medium text-ink truncate"><%= allocation.option %></p>
+      <p class="font-medium text-ink truncate"><%= allocation.display_label %></p>
       <% if allocation.note.present? %>
         <p class="mt-1 text-sm text-ink-soft"><%= allocation.note %></p>
       <% end %>
@@ -20,5 +21,5 @@
     </div>
   </div>
 
-  <%= render "allocation_modal", allocation: allocation %>
+  <%= render "allocation_modal", allocation: allocation, scenario: scenario %>
 </div>

--- a/app/views/scenarios/_allocation_modal.html.erb
+++ b/app/views/scenarios/_allocation_modal.html.erb
@@ -1,17 +1,14 @@
+<%# locals: (allocation:, scenario:) %>
 <% klass = allocation.class %>
 <% editing = allocation.persisted? %>
 <% suffix = editing ? dom_id(allocation) : klass.model_name.element %>
 <% percentage = allocation.percentage || 20 %>
 <dialog data-dialog-target="dialog" class="m-auto w-full max-w-lg rounded-2xl p-0 shadow-lg backdrop:bg-[rgba(20,18,14,0.48)]">
-  <%= form_with url: (editing ? scenario_allocation_path(@scenario, allocation) : scenario_allocations_path(@scenario)), method: (editing ? :patch : :post), class: "p-8" do |form| %>
+  <%= form_with url: (editing ? scenario_allocation_path(scenario, allocation) : scenario_allocations_path(scenario)), method: (editing ? :patch : :post), class: "p-8" do |form| %>
     <%= hidden_field_tag "allocation[type]", klass.name %>
     <h2 class="font-serif font-medium text-2xl text-ink"><%= editing ? "Edit allocation" : "Create allocation" %></h2>
 
-    <div class="mt-6">
-      <%= label_tag "allocation_option_#{suffix}", "Option", class: "block text-sm text-ink-soft" %>
-      <%= text_field_tag "allocation[option]", allocation.option, id: "allocation_option_#{suffix}", required: true,
-            class: "mt-1 block w-full rounded-md border border-line bg-surface px-3 py-2 shadow-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
-    </div>
+    <%= render "scenarios/category_picker", allocation: allocation, scenario: scenario %>
 
     <% if klass == Allocation::Ongoing %>
       <div class="mt-6" data-controller="range">

--- a/app/views/scenarios/_allocation_section.html.erb
+++ b/app/views/scenarios/_allocation_section.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (title:, klass:, allocations:, scenario:) %>
 <div class="mt-6" data-controller="dialog">
   <div class="flex items-center justify-between">
     <h3 class="text-[12px] font-semibold uppercase tracking-wide text-ink-soft"><%= title %></h3>
@@ -10,7 +11,7 @@
 
   <% if allocations.any? %>
     <div class="mt-3 space-y-2">
-      <%= render partial: "allocation", collection: allocations %>
+      <%= render partial: "allocation", collection: allocations, locals: { scenario: scenario } %>
     </div>
   <% else %>
     <div class="mt-3 rounded-xl border border-line-soft bg-surface-soft py-12 text-center text-ink-faint">
@@ -18,5 +19,5 @@
     </div>
   <% end %>
 
-  <%= render "allocation_modal", allocation: klass.new %>
+  <%= render "allocation_modal", allocation: klass.new, scenario: scenario %>
 </div>

--- a/app/views/scenarios/_category_picker.html.erb
+++ b/app/views/scenarios/_category_picker.html.erb
@@ -1,0 +1,64 @@
+<%# locals: (allocation:, scenario:) %>
+<% categories = scenario.organization.allocation_categories.order(:name).to_a %>
+<% children_by_parent = categories.group_by(&:parent_id) %>
+<% selected = allocation.allocation_category %>
+<% initial_type = selected&.type || AllocationCategory::TAB_CLASSES.first %>
+
+<div class="mt-6" data-controller="allocation-category-picker"
+     data-allocation-category-picker-active-tab-class="text-ink border-ink"
+     data-allocation-category-picker-inactive-tab-class="text-ink-faint border-transparent">
+  <span class="block text-sm text-ink-soft">Category</span>
+
+  <%= hidden_field_tag "allocation[allocation_category_id]", allocation.allocation_category_id,
+        data: { allocation_category_picker_target: "categoryId" } %>
+  <%= hidden_field_tag "allocation[option]", (selected ? nil : allocation.option),
+        data: { allocation_category_picker_target: "optionField" } %>
+
+  <button type="button" data-action="allocation-category-picker#toggle:prevent"
+          class="mt-1 flex w-full items-center justify-between rounded-md border border-line bg-surface px-3 py-2 text-left shadow-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10">
+    <span data-allocation-category-picker-target="label" class="<%= "text-ink-faint" if allocation.display_label.blank? %>">
+      <%= allocation.display_label.presence || "Select a category" %>
+    </span>
+    <span class="text-ink-faint">▾</span>
+  </button>
+
+  <div data-allocation-category-picker-target="panel" hidden
+       class="mt-2 rounded-xl border border-line bg-surface shadow-lg">
+    <div class="border-b border-line-soft p-3">
+      <%= text_field_tag :category_search, nil, placeholder: "Search…",
+            data: { allocation_category_picker_target: "search", action: "input->allocation-category-picker#filter" },
+            class: "block w-full rounded-md border border-line bg-canvas px-3 py-2 text-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
+    </div>
+
+    <div class="flex gap-6 border-b border-line-soft px-3">
+      <% AllocationCategory::TAB_CLASSES.each do |klass_name| %>
+        <button type="button" data-action="allocation-category-picker#switchTab:prevent"
+                data-allocation-category-picker-target="tab" data-type="<%= klass_name %>"
+                data-active="<%= klass_name == initial_type %>"
+                class="border-b-2 border-transparent py-3 text-sm text-ink-faint">
+          <%= klass_name.constantize.tab_label %>
+        </button>
+      <% end %>
+    </div>
+
+    <% AllocationCategory::TAB_CLASSES.each do |klass_name| %>
+      <div data-allocation-category-picker-target="tabPanel" data-type="<%= klass_name %>"
+           class="max-h-72 overflow-y-auto py-1 <%= "hidden" unless klass_name == initial_type %>">
+        <% roots = (children_by_parent[nil] || []).select { |c| c.type == klass_name } %>
+        <% if roots.empty? %>
+          <p class="px-4 py-3 text-sm text-ink-faint">No categories yet.</p>
+        <% else %>
+          <% roots.each do |root| %>
+            <%= render "scenarios/category_row", category: root, children_by_parent: children_by_parent, depth: 0 %>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
+
+    <div class="border-t border-line-soft p-3">
+      <%= text_field_tag :custom_option, nil, placeholder: "+ Type a custom option and press Enter…",
+            data: { allocation_category_picker_target: "customInput", action: "keydown.enter->allocation-category-picker#addCustom:prevent" },
+            class: "block w-full rounded-md border border-line bg-canvas px-3 py-2 text-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
+    </div>
+  </div>
+</div>

--- a/app/views/scenarios/_category_row.html.erb
+++ b/app/views/scenarios/_category_row.html.erb
@@ -1,0 +1,12 @@
+<%# locals: (category:, children_by_parent:, depth:) %>
+<button type="button" data-action="allocation-category-picker#select:prevent"
+        data-allocation-category-picker-target="row" data-id="<%= category.id %>" data-name="<%= category.name %>"
+        style="padding-left: <%= 1 + depth * 1.25 %>rem"
+        class="flex w-full items-center justify-between py-2 pr-4 text-left text-sm text-ink hover:bg-canvas">
+  <span><%= category.name %></span>
+  <span class="text-xs text-ink-faint"><%= category.class.tab_label %></span>
+</button>
+
+<% (children_by_parent[category.id] || []).each do |child| %>
+  <%= render "scenarios/category_row", category: child, children_by_parent: children_by_parent, depth: depth + 1 %>
+<% end %>

--- a/app/views/scenarios/names/_form.html.erb
+++ b/app/views/scenarios/names/_form.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (scenario:) %>
 <%= turbo_frame_tag dom_id(scenario, :name), class: "mt-6 block" do %>
   <%= form_with model: scenario, url: scenario_name_path(scenario), method: :patch, class: "flex items-center gap-2" do |form| %>
     <%= form.text_field :name, required: true, autofocus: true,

--- a/app/views/scenarios/names/_name.html.erb
+++ b/app/views/scenarios/names/_name.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (scenario:) %>
 <%= turbo_frame_tag dom_id(scenario, :name), class: "mt-6 block" do %>
   <%= link_to edit_scenario_name_path(scenario), class: "group inline-flex items-center gap-2" do %>
     <h1 class="font-serif font-medium text-3xl tracking-tight text-ink"><%= scenario.name %></h1>

--- a/app/views/scenarios/show.html.erb
+++ b/app/views/scenarios/show.html.erb
@@ -15,12 +15,14 @@
       <%= render "allocation_section",
             title: "On going giving",
             klass: Allocation::Ongoing,
-            allocations: @scenario.ongoing_allocations %>
+            allocations: @scenario.ongoing_allocations,
+            scenario: @scenario %>
 
       <%= render "allocation_section",
             title: "One time giving",
             klass: Allocation::OneTime,
-            allocations: @scenario.one_time_allocations %>
+            allocations: @scenario.one_time_allocations,
+            scenario: @scenario %>
     </div>
 
     <!-- Summary -->
@@ -34,7 +36,7 @@
           <ul class="mt-3 space-y-2">
             <% @scenario.ongoing_allocations.each do |allocation| %>
               <li class="flex justify-between text-ink-soft">
-                <span><%= allocation.option %></span>
+                <span><%= allocation.display_label %></span>
                 <span class="font-medium text-ink"><%= allocation.percentage %>%</span>
               </li>
             <% end %>
@@ -54,7 +56,7 @@
           <ul class="mt-3 space-y-2">
             <% @scenario.one_time_allocations.each do |allocation| %>
               <li class="flex justify-between text-ink-soft">
-                <span><%= allocation.option %></span>
+                <span><%= allocation.display_label %></span>
                 <span class="font-medium text-ink"><%= number_to_currency(allocation.amount, precision: 0) %></span>
               </li>
             <% end %>

--- a/app/views/scenarios/total_giving_amounts/_form.html.erb
+++ b/app/views/scenarios/total_giving_amounts/_form.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (scenario:) %>
 <%= turbo_frame_tag dom_id(scenario, :total_giving_amount), class: "mt-6 block" do %>
   <div class="rounded-2xl border border-line bg-surface p-6 shadow-sm">
     <%= form_with model: scenario, url: scenario_total_giving_amount_path(scenario), method: :patch, class: "flex items-center gap-4" do |form| %>

--- a/app/views/scenarios/total_giving_amounts/_total_giving_amount.html.erb
+++ b/app/views/scenarios/total_giving_amounts/_total_giving_amount.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (scenario:) %>
 <%= turbo_frame_tag dom_id(scenario, :total_giving_amount), class: "mt-6 block" do %>
   <div class="rounded-2xl border border-line bg-surface p-6 shadow-sm">
     <div class="flex items-center gap-4">

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,3 +1,4 @@
+<%# locals: () %>
 <div class="fixed top-16 right-4 z-40 flex w-full max-w-sm flex-col gap-2 sm:right-6">
   <% flash.each do |type, message| %>
     <% next if message.blank? %>

--- a/db/migrate/20260623160000_create_allocation_categories.rb
+++ b/db/migrate/20260623160000_create_allocation_categories.rb
@@ -1,0 +1,14 @@
+class CreateAllocationCategories < ActiveRecord::Migration[8.1]
+  def change
+    create_table :allocation_categories do |t|
+      t.references :organization, null: false, foreign_key: true
+      t.string :type, null: false
+      t.string :name, null: false
+      t.references :parent, foreign_key: { to_table: :allocation_categories }
+
+      t.timestamps
+    end
+
+    add_index :allocation_categories, [ :organization_id, :type ]
+  end
+end

--- a/db/migrate/20260623160001_add_allocation_category_to_allocations.rb
+++ b/db/migrate/20260623160001_add_allocation_category_to_allocations.rb
@@ -1,0 +1,6 @@
+class AddAllocationCategoryToAllocations < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :allocations, :allocation_category, foreign_key: true
+    change_column_null :allocations, :option, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_23_152634) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_23_160001) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -39,15 +39,29 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_23_152634) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "allocation_categories", force: :cascade do |t|
+    t.integer "organization_id", null: false
+    t.string "type", null: false
+    t.string "name", null: false
+    t.integer "parent_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["organization_id", "type"], name: "index_allocation_categories_on_organization_id_and_type"
+    t.index ["organization_id"], name: "index_allocation_categories_on_organization_id"
+    t.index ["parent_id"], name: "index_allocation_categories_on_parent_id"
+  end
+
   create_table "allocations", force: :cascade do |t|
     t.integer "scenario_id", null: false
     t.string "type", null: false
-    t.string "option", null: false
+    t.string "option"
     t.integer "percentage"
     t.integer "amount"
     t.text "note"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "allocation_category_id"
+    t.index ["allocation_category_id"], name: "index_allocations_on_allocation_category_id"
     t.index ["scenario_id"], name: "index_allocations_on_scenario_id"
   end
 
@@ -105,6 +119,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_23_152634) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "allocation_categories", "allocation_categories", column: "parent_id"
+  add_foreign_key "allocation_categories", "organizations"
+  add_foreign_key "allocations", "allocation_categories"
   add_foreign_key "allocations", "scenarios"
   add_foreign_key "organization_memberships", "organizations"
   add_foreign_key "organization_memberships", "users"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -29,6 +29,49 @@ end
   membership.update!(role: role)
 end
 
+# These were provided by Arlington Community Foundation
+ALLOCATION_CATEGORIES = {
+  "AllocationCategory::Program" => {
+    "Arts & Culture" => [],
+    "Education" => [
+      "Early Childhood Education", "Primary & Secondary Education",
+      "Higher Education", "Vocational & Technical Education", "Other Education"
+    ],
+    "Environment" => [],
+    "Animal-Related" => [],
+    "Health Care" => [
+      "Traditional Health Care", "Mental Health",
+      "Diseases, Disorders & Medical Disciplines", "Medical Research"
+    ],
+    "Crime & Legal-Related" => [],
+    "Basic Needs" => [ "Employment", "Food and Nutrition", "Housing & Shelter", "Human Services" ],
+    "Public Safety, Disaster Preparedness and Relief" => [],
+    "Recreation and Sports" => [],
+    "International and Foreign Affairs" => [],
+    "Civil Rights & Social Action" => [],
+    "Community Improvement & Capacity Building" => [],
+    "Philanthropy & Voluntarism" => [],
+    "Religion & Spirituality" => []
+  },
+  "AllocationCategory::Population" => {
+    "Children and Youth" => [], "Elderly" => [], "BIPOC" => [], "Disabled" => [],
+    "LGBTQIA+" => [], "Low-Income" => [], "Unhoused" => [], "Veterans" => [],
+    "Women" => [], "Immigrants" => [], "Formerly Incarcerated" => []
+  }
+}.freeze
+
+ALLOCATION_CATEGORIES.each do |type, roots|
+  roots.each do |root_name, child_names|
+    root = arlington.allocation_categories.find_or_create_by!(type: type, name: root_name, parent: nil)
+    child_names.each do |child_name|
+      arlington.allocation_categories.find_or_create_by!(type: type, name: child_name, parent: root)
+    end
+  end
+end
+
+education_category = arlington.allocation_categories.find_by!(name: "Education")
+youth_category = arlington.allocation_categories.find_by!(name: "Children and Youth")
+
 owner = User.find_by!(email_address: "owner@example.com")
 
 balanced = owner.scenarios.find_or_create_by!(organization: arlington, name: "Balanced giving") do |scenario|
@@ -36,9 +79,10 @@ balanced = owner.scenarios.find_or_create_by!(organization: arlington, name: "Ba
 end
 
 if balanced.allocations.empty?
+  balanced.ongoing_allocations.create!(allocation_category: education_category, percentage: 30)
+  balanced.ongoing_allocations.create!(allocation_category: youth_category, percentage: 40)
+  # Demonstrates the free-text fallback for needs without a curated category.
   balanced.ongoing_allocations.create!(option: "Greatest Community Need", percentage: 30)
-  balanced.ongoing_allocations.create!(option: "Program: Education", percentage: 30)
-  balanced.ongoing_allocations.create!(option: "Population: Youth", percentage: 40)
   balanced.one_time_allocations.create!(option: "Specific org", amount: 1_000)
 end
 
@@ -47,8 +91,8 @@ education = owner.scenarios.find_or_create_by!(organization: arlington, name: "E
 end
 
 if education.allocations.empty?
-  education.ongoing_allocations.create!(option: "Program: Education", percentage: 60)
-  education.ongoing_allocations.create!(option: "Population: Youth (5–21)", percentage: 25)
+  education.ongoing_allocations.create!(allocation_category: education_category, percentage: 60)
+  education.ongoing_allocations.create!(allocation_category: youth_category, percentage: 25)
   education.ongoing_allocations.create!(option: "Greatest Community Need", percentage: 15)
   education.one_time_allocations.create!(option: "Scholarship Fund", amount: 500)
 end

--- a/test/controllers/allocations_controller_test.rb
+++ b/test/controllers/allocations_controller_test.rb
@@ -16,6 +16,17 @@ class AllocationsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to scenario_path(@scenario)
   end
 
+  test "creates an allocation targeting a category" do
+    category = allocation_categories(:population_youth)
+    assert_difference -> { @scenario.allocations.count }, 1 do
+      post scenario_allocations_url(@scenario), params: {
+        allocation: { type: "Allocation::Ongoing", allocation_category_id: category.id, option: "", percentage: 25 }
+      }
+    end
+    assert_redirected_to scenario_path(@scenario)
+    assert_equal category, @scenario.allocations.order(:created_at).last.allocation_category
+  end
+
   test "creates a one time allocation" do
     assert_difference -> { @scenario.allocations.count }, 1 do
       post scenario_allocations_url(@scenario), params: {

--- a/test/fixtures/allocation_categories.yml
+++ b/test/fixtures/allocation_categories.yml
@@ -1,0 +1,15 @@
+program_education:
+  organization: arlington
+  type: AllocationCategory::Program
+  name: Education
+
+program_higher_education:
+  organization: arlington
+  type: AllocationCategory::Program
+  name: Higher Education
+  parent: program_education
+
+population_youth:
+  organization: arlington
+  type: AllocationCategory::Population
+  name: Children and Youth

--- a/test/fixtures/allocations.yml
+++ b/test/fixtures/allocations.yml
@@ -1,11 +1,13 @@
+# greatest_need uses the free-text option fallback (no category).
 greatest_need:
   scenario: one_arlington
   type: Allocation::Ongoing
   option: Greatest Community Need
   percentage: 30
 
+# education_grant targets a curated category instead of a free-text option.
 education_grant:
   scenario: one_arlington
   type: Allocation::OneTime
-  option: "Program: Education"
+  allocation_category: program_education
   amount: 5000

--- a/test/models/allocation_category_test.rb
+++ b/test/models/allocation_category_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+class AllocationCategoryTest < ActiveSupport::TestCase
+  setup { @organization = organizations(:arlington) }
+
+  test "requires a name" do
+    category = @organization.allocation_categories.build(type: "AllocationCategory::Program")
+    assert_not category.valid?
+    assert_includes category.errors[:name], "can't be blank"
+  end
+
+  test "persists its STI subclass via the type column" do
+    category = AllocationCategory::Population.create!(organization: @organization, name: "Veterans")
+    assert_equal "AllocationCategory::Population", category.reload.type
+    assert_instance_of AllocationCategory::Population, AllocationCategory.find(category.id)
+  end
+
+  test "nests children under a parent" do
+    parent = allocation_categories(:program_education)
+    child = allocation_categories(:program_higher_education)
+    assert_equal parent, child.parent
+    assert_includes parent.children, child
+  end
+
+  test "roots scope returns only top-level categories" do
+    roots = @organization.allocation_categories.roots
+    assert_includes roots, allocation_categories(:program_education)
+    assert_not_includes roots, allocation_categories(:program_higher_education)
+  end
+
+  test "belongs to the top-level Organization" do
+    assert_instance_of Organization, allocation_categories(:program_education).organization
+  end
+
+  test "tab_label is human readable per subclass" do
+    assert_equal "Program", AllocationCategory::Program.tab_label
+    assert_equal "Organization", AllocationCategory::Organization.tab_label
+  end
+end

--- a/test/models/allocation_test.rb
+++ b/test/models/allocation_test.rb
@@ -3,10 +3,21 @@ require "test_helper"
 class AllocationTest < ActiveSupport::TestCase
   setup { @scenario = scenarios(:one_arlington) }
 
-  test "requires an option" do
-    allocation = @scenario.ongoing_allocations.new(percentage: 10, option: "")
-    assert_not allocation.valid?
-    assert_includes allocation.errors[:option], "can't be blank"
+  test "requires a category or an option" do
+    neither = @scenario.ongoing_allocations.new(percentage: 10)
+    assert_not neither.valid?
+    assert_includes neither.errors[:base], "Choose a category or enter a custom option"
+
+    with_option = @scenario.ongoing_allocations.new(percentage: 10, option: "Custom")
+    assert with_option.valid?
+
+    with_category = @scenario.ongoing_allocations.new(percentage: 10, allocation_category: allocation_categories(:population_youth))
+    assert with_category.valid?
+  end
+
+  test "display_label prefers the category name, falling back to the option" do
+    assert_equal "Education", allocations(:education_grant).display_label
+    assert_equal "Greatest Community Need", allocations(:greatest_need).display_label
   end
 
   test "ongoing requires a percentage between 0 and 100" do


### PR DESCRIPTION
Replaces the free-text allocation `option` with a structured, per-organization `AllocationCategory` (single-table inheritance: Program / Population / Organization) that supports nesting via a self-referential parent, while keeping `option` as an optional free-text fallback exposed through a new `Allocation#display_label`. The allocation modal now uses a tabbed, searchable category picker (a Stimulus controller plus `_category_picker`/`_category_row` partials), and each foundation is seeded with the Arlington-provided category list. This branch also adds Rails strict locals to every partial and enforces them through herb's `erb-strict-locals-required` rule in a new `.herb.yml`, threading `scenario` as an explicit local so partials no longer reach for `@scenario`. New migrations add the `allocation_categories` table and a nullable `allocation_category_id` on `allocations` (and make `option` nullable). Covered by new model/controller tests and fixtures; the full suite (167 tests) and `herb lint` both pass.