### PR TITLE
Add admin CRUD for allocation categories

### DIFF
--- a/app/controllers/admin/allocation_categories_controller.rb
+++ b/app/controllers/admin/allocation_categories_controller.rb
@@ -1,0 +1,51 @@
+class Admin::AllocationCategoriesController < Admin::ApplicationController
+  before_action :set_category, only: %i[ edit update destroy ]
+
+  def index
+    @categories = categories.order(:name).to_a
+  end
+
+  def new
+    type = params[:type].presence_in(AllocationCategory::TAB_CLASSES) || AllocationCategory::TAB_CLASSES.first
+    @category = categories.new(type: type)
+  end
+
+  def create
+    @category = categories.new(category_params)
+    if @category.save
+      redirect_to admin_allocation_categories_path(type: @category.type), notice: "Category created."
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @category.update(category_params)
+      redirect_to admin_allocation_categories_path(type: @category.type), notice: "Category updated."
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @category.destroy
+    redirect_to admin_allocation_categories_path(type: @category.type), notice: "Category deleted."
+  end
+
+  private
+
+  def categories
+    Current.organization.allocation_categories
+  end
+
+  def set_category
+    @category = categories.find(params[:id])
+  end
+
+  def category_params
+    params.require(:allocation_category).permit(:name, :type, :parent_id)
+  end
+end

--- a/app/helpers/admin/allocation_categories_helper.rb
+++ b/app/helpers/admin/allocation_categories_helper.rb
@@ -1,0 +1,15 @@
+module Admin::AllocationCategoriesHelper
+  def parent_options(category)
+    scope = Current.organization.allocation_categories.where(type: category.type).order(:name)
+    return scope if category.new_record?
+
+    excluded_ids = [ category.id ] + descendant_ids(category)
+    scope.where.not(id: excluded_ids)
+  end
+
+  private
+
+  def descendant_ids(category)
+    category.children.flat_map { |child| [ child.id ] + descendant_ids(child) }
+  end
+end

--- a/app/javascript/controllers/tabs_controller.js
+++ b/app/javascript/controllers/tabs_controller.js
@@ -1,0 +1,27 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["tab", "panel"]
+  static classes = ["activeTab", "inactiveTab"]
+
+  connect() {
+    const active = this.tabTargets.find((tab) => tab.dataset.active === "true") || this.tabTargets[0]
+    if (active) this.activate(active.dataset.type)
+  }
+
+  switch(event) {
+    this.activate(event.params.type)
+  }
+
+  activate(type) {
+    this.tabTargets.forEach((tab) => {
+      const on = tab.dataset.type === type
+      tab.classList.add(...(on ? this.activeTabClasses : this.inactiveTabClasses))
+      tab.classList.remove(...(on ? this.inactiveTabClasses : this.activeTabClasses))
+    })
+    this.panelTargets.forEach((panel) => {
+      panel.classList.toggle("hidden", panel.dataset.type !== type)
+    })
+    this.dispatch("change", { detail: { type } })
+  }
+}

--- a/app/javascript/controllers/typed_link_controller.js
+++ b/app/javascript/controllers/typed_link_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = { basePath: String, type: String }
+
+  connect() {
+    this.setType(this.typeValue)
+  }
+
+  update(event) {
+    this.setType(event.detail.type)
+  }
+
+  setType(type) {
+    if (!type) return
+    this.element.href = `${this.basePathValue}?type=${encodeURIComponent(type)}`
+  }
+}

--- a/app/models/allocation_category.rb
+++ b/app/models/allocation_category.rb
@@ -5,6 +5,8 @@ class AllocationCategory < ApplicationRecord
   has_many :allocations, dependent: :nullify
 
   validates :name, presence: true
+  validates :type, inclusion: { in: ->(_) { TAB_CLASSES } }
+  validate :parent_matches_organization_and_type
 
   scope :roots, -> { where(parent_id: nil) }
 
@@ -12,5 +14,14 @@ class AllocationCategory < ApplicationRecord
 
   def self.tab_label
     name.demodulize.titleize
+  end
+
+  private
+
+  def parent_matches_organization_and_type
+    return if parent.nil?
+
+    errors.add(:parent, "must belong to the same organization") if parent.organization_id != organization_id
+    errors.add(:parent, "must be the same type") if parent.type != type
   end
 end

--- a/app/views/admin/allocation_categories/_form.html.erb
+++ b/app/views/admin/allocation_categories/_form.html.erb
@@ -1,0 +1,37 @@
+<%# locals: (category:, submit_label:) %>
+<%= form_with model: category, scope: :allocation_category,
+      url: (category.persisted? ? admin_allocation_category_path(category) : admin_allocation_categories_path),
+      method: (category.persisted? ? :patch : :post), class: "contents" do |form| %>
+  <% if category.errors.any? %>
+    <p class="mt-5 py-2 px-3 bg-danger-tint text-danger font-medium rounded-lg inline-block">
+      <%= category.errors.full_messages.to_sentence %>
+    </p>
+  <% end %>
+
+  <div class="mt-6">
+    <%= form.label :type, "Type", class: "block text-ink-soft" %>
+    <%= form.select :type,
+          AllocationCategory::TAB_CLASSES.map { |klass| [ klass.constantize.tab_label, klass ] },
+          {},
+          class: "mt-2 block w-full rounded-md border border-line bg-surface px-3 py-2 shadow-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
+  </div>
+
+  <div class="mt-6">
+    <%= form.label :name, class: "block text-ink-soft" %>
+    <%= form.text_field :name, required: true, placeholder: "e.g. Education",
+          class: "mt-2 block w-full rounded-md border border-line bg-surface px-3 py-2 shadow-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
+  </div>
+
+  <div class="mt-6">
+    <%= form.label :parent_id, "Parent category", class: "block text-ink-soft" %>
+    <p class="mt-1 text-sm text-ink-faint">Optional. A parent must be the same type.</p>
+    <%= form.collection_select :parent_id, parent_options(category), :id, :name,
+          { include_blank: "None (top level)" },
+          class: "mt-2 block w-full rounded-md border border-line bg-surface px-3 py-2 shadow-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
+  </div>
+
+  <div class="mt-6 flex items-center gap-3">
+    <%= form.submit submit_label, class: "rounded-md px-3.5 py-2.5 bg-accent hover:bg-[#444] text-white font-medium cursor-pointer transition" %>
+    <%= link_to "Cancel", admin_allocation_categories_path(type: category.type), class: "text-ink-soft hover:underline" %>
+  </div>
+<% end %>

--- a/app/views/admin/allocation_categories/_row.html.erb
+++ b/app/views/admin/allocation_categories/_row.html.erb
@@ -1,0 +1,16 @@
+<%# locals: (category:, children_by_parent:, depth:) %>
+<tr class="bg-surface hover:bg-surface-soft transition">
+  <td class="px-4 py-2.5 text-ink" style="padding-left: <%= 1 + depth * 1.5 %>rem">
+    <% if depth.positive? %><span class="text-ink-faint">↳ </span><% end %>
+    <span class="<%= "font-medium" if depth.zero? %>"><%= category.name %></span>
+  </td>
+  <td class="px-4 py-2.5 text-right whitespace-nowrap">
+    <%= link_to "Edit", edit_admin_allocation_category_path(category), class: "text-brand hover:underline" %>
+    <%= button_to "Delete", admin_allocation_category_path(category), method: :delete,
+          form: { class: "inline", data: { turbo_confirm: "Delete this category and any sub-categories?" } },
+          class: "ml-3 text-danger hover:underline cursor-pointer bg-transparent" %>
+  </td>
+</tr>
+<% (children_by_parent[category.id] || []).each do |child| %>
+  <%= render "row", category: child, children_by_parent: children_by_parent, depth: depth + 1 %>
+<% end %>

--- a/app/views/admin/allocation_categories/edit.html.erb
+++ b/app/views/admin/allocation_categories/edit.html.erb
@@ -1,0 +1,8 @@
+<% content_for :title, "Edit category" %>
+
+<div class="mx-auto max-w-xl w-full px-6 py-10">
+  <p class="text-xs font-semibold uppercase tracking-wider text-ink-faint">Admin</p>
+  <h1 class="mt-1 text-2xl font-semibold tracking-tight text-ink">Edit category</h1>
+
+  <%= render "form", category: @category, submit_label: "Save changes" %>
+</div>

--- a/app/views/admin/allocation_categories/index.html.erb
+++ b/app/views/admin/allocation_categories/index.html.erb
@@ -1,0 +1,57 @@
+<% content_for :title, "Allocation categories" %>
+
+<% children_by_parent = @categories.group_by(&:parent_id) %>
+<% active_type = params[:type].presence_in(AllocationCategory::TAB_CLASSES) || AllocationCategory::TAB_CLASSES.first %>
+
+<div class="mx-auto max-w-6xl w-full px-6 py-10" data-controller="tabs"
+     data-tabs-active-tab-class="text-ink border-ink"
+     data-tabs-inactive-tab-class="text-ink-faint border-transparent">
+  <div class="flex flex-wrap items-end justify-between gap-4 border-b border-line pb-5">
+    <div>
+      <p class="text-xs font-semibold uppercase tracking-wider text-ink-faint">Admin</p>
+      <h1 class="mt-1 text-2xl font-semibold tracking-tight text-ink">Allocation categories</h1>
+    </div>
+    <div class="flex items-center gap-3">
+      <%= link_to "← Dashboard", admin_scenarios_path,
+            class: "rounded border border-line px-2.5 py-1.5 text-sm text-ink-soft hover:bg-surface-soft hover:text-ink" %>
+      <%= link_to "New category", new_admin_allocation_category_path,
+            data: { controller: "typed-link", action: "tabs:change@window->typed-link#update",
+                    typed_link_base_path_value: new_admin_allocation_category_path,
+                    typed_link_type_value: active_type },
+            class: "rounded-md px-3.5 py-2 bg-accent hover:bg-[#444] text-sm text-white font-medium transition" %>
+    </div>
+  </div>
+
+  <div class="mt-6">
+    <div class="flex gap-6 border-b border-line">
+      <% AllocationCategory::TAB_CLASSES.each do |klass_name| %>
+        <button type="button" data-action="tabs#switch" data-tabs-type-param="<%= klass_name %>"
+                data-tabs-target="tab" data-type="<%= klass_name %>" data-active="<%= klass_name == active_type %>"
+                class="-mb-px border-b-2 border-transparent py-3 text-sm text-ink-faint">
+          <%= klass_name.constantize.tab_label %>
+        </button>
+      <% end %>
+    </div>
+
+    <% AllocationCategory::TAB_CLASSES.each do |klass_name| %>
+      <% roots = (children_by_parent[nil] || []).select { |c| c.type == klass_name } %>
+      <div data-tabs-target="panel" data-type="<%= klass_name %>" class="mt-5 <%= "hidden" unless klass_name == active_type %>">
+        <div class="overflow-hidden rounded-lg border border-line">
+          <table class="w-full text-left text-sm">
+            <tbody class="divide-y divide-line-soft">
+              <% if roots.empty? %>
+                <tr class="bg-surface">
+                  <td class="px-4 py-8 text-center text-ink-faint">No categories yet.</td>
+                </tr>
+              <% else %>
+                <% roots.each do |root| %>
+                  <%= render "row", category: root, children_by_parent: children_by_parent, depth: 0 %>
+                <% end %>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/allocation_categories/new.html.erb
+++ b/app/views/admin/allocation_categories/new.html.erb
@@ -1,0 +1,8 @@
+<% content_for :title, "New category" %>
+
+<div class="mx-auto max-w-xl w-full px-6 py-10">
+  <p class="text-xs font-semibold uppercase tracking-wider text-ink-faint">Admin</p>
+  <h1 class="mt-1 text-2xl font-semibold tracking-tight text-ink">New category</h1>
+
+  <%= render "form", category: @category, submit_label: "Create category" %>
+</div>

--- a/app/views/admin/scenarios/index.html.erb
+++ b/app/views/admin/scenarios/index.html.erb
@@ -6,13 +6,17 @@
       <p class="text-xs font-semibold uppercase tracking-wider text-ink-faint">Admin</p>
       <h1 class="mt-1 text-2xl font-semibold tracking-tight text-ink">Scenarios</h1>
     </div>
-    <%= form_with url: admin_scenarios_path, method: :get,
-          data: { controller: "debounced-form", action: "input->debounced-form#submit",
-                  turbo_frame: "scenarios_table", turbo_action: "advance" } do |form| %>
-      <%= form.search_field :q, value: @query,
-            placeholder: "Filter by user…", autocomplete: "off",
-            class: "block w-64 rounded-md border border-line bg-surface px-3 py-1.5 text-sm text-ink placeholder:text-ink-faint focus:border-ink-soft focus:outline-none" %>
-    <% end %>
+    <div class="flex items-center gap-3">
+      <%= link_to "Manage categories", admin_allocation_categories_path,
+            class: "rounded border border-line px-2.5 py-1.5 text-sm text-ink-soft hover:bg-surface-soft hover:text-ink" %>
+      <%= form_with url: admin_scenarios_path, method: :get,
+            data: { controller: "debounced-form", action: "input->debounced-form#submit",
+                    turbo_frame: "scenarios_table", turbo_action: "advance" } do |form| %>
+        <%= form.search_field :q, value: @query,
+              placeholder: "Filter by user…", autocomplete: "off",
+              class: "block w-64 rounded-md border border-line bg-surface px-3 py-1.5 text-sm text-ink placeholder:text-ink-faint focus:border-ink-soft focus:outline-none" %>
+      <% end %>
+    </div>
   </div>
 
   <%= turbo_frame_tag "scenarios_table", class: "mt-5 block", data: { turbo_action: "advance" } do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :scenarios, only: :index
+    resources :allocation_categories, only: %i[ index new create edit update destroy ]
   end
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/test/controllers/admin/allocation_categories_controller_test.rb
+++ b/test/controllers/admin/allocation_categories_controller_test.rb
@@ -1,0 +1,127 @@
+require "test_helper"
+
+class Admin::AllocationCategoriesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    host! "arlington.localhost"
+    @owner = users(:one)
+    @admin = users(:admin)
+    @member = users(:passwordless)
+    @education = allocation_categories(:program_education)
+  end
+
+  test "owners and admins can view the index" do
+    sign_in_as(@owner)
+    get admin_allocation_categories_path
+    assert_response :success
+
+    sign_in_as(@admin)
+    get admin_allocation_categories_path
+    assert_response :success
+  end
+
+  test "plain members are redirected away" do
+    sign_in_as(@member)
+    get admin_allocation_categories_path
+    assert_redirected_to root_path
+  end
+
+  test "index groups the org's categories by type and nests children" do
+    sign_in_as(@owner)
+    get admin_allocation_categories_path
+
+    assert_select "td", text: /Education/
+    assert_select "td", text: /Higher Education/
+    assert_select "td", text: /Children and Youth/
+  end
+
+  test "index does not show another organization's categories" do
+    sign_in_as(@owner)
+    get admin_allocation_categories_path
+
+    assert_select "td", text: /Boston Arts/, count: 0
+  end
+
+  test "index marks the requested type as the active tab" do
+    sign_in_as(@owner)
+    get admin_allocation_categories_path(type: "AllocationCategory::Population")
+    assert_select "button[data-tabs-target='tab'][data-type='AllocationCategory::Population'][data-active='true']"
+    assert_select "button[data-tabs-target='tab'][data-type='AllocationCategory::Program'][data-active='false']"
+  end
+
+  test "new defaults the type to the requested tab" do
+    sign_in_as(@owner)
+    get new_admin_allocation_category_path(type: "AllocationCategory::Population")
+    assert_select "select[name='allocation_category[type]'] option[selected][value='AllocationCategory::Population']"
+  end
+
+  test "new falls back to the first type when the requested type is invalid" do
+    sign_in_as(@owner)
+    get new_admin_allocation_category_path(type: "Nonsense")
+    assert_select "select[name='allocation_category[type]'] option[selected][value=?]",
+      AllocationCategory::TAB_CLASSES.first
+  end
+
+  test "create makes a category of the chosen type for the current org" do
+    sign_in_as(@owner)
+    assert_difference -> { organizations(:arlington).allocation_categories.count }, 1 do
+      post admin_allocation_categories_path, params: {
+        allocation_category: { type: "AllocationCategory::Population", name: "Veterans" }
+      }
+    end
+    category = organizations(:arlington).allocation_categories.order(:created_at).last
+    assert_equal "AllocationCategory::Population", category.type
+    assert_equal "Veterans", category.name
+    assert_redirected_to admin_allocation_categories_path(type: "AllocationCategory::Population")
+  end
+
+  test "create with a blank name re-renders the form" do
+    sign_in_as(@owner)
+    assert_no_difference -> { AllocationCategory.count } do
+      post admin_allocation_categories_path, params: {
+        allocation_category: { type: "AllocationCategory::Program", name: "" }
+      }
+    end
+    assert_response :unprocessable_entity
+  end
+
+  test "create rejects a type outside the allowed list" do
+    sign_in_as(@owner)
+    assert_no_difference -> { AllocationCategory.count } do
+      post admin_allocation_categories_path, params: {
+        allocation_category: { type: "AllocationCategory", name: "Sneaky" }
+      }
+    end
+    assert_response :unprocessable_entity
+  end
+
+  test "update changes the name" do
+    sign_in_as(@owner)
+    patch admin_allocation_category_path(@education), params: {
+      allocation_category: { name: "Schooling" }
+    }
+    assert_equal "Schooling", @education.reload.name
+    assert_redirected_to admin_allocation_categories_path(type: @education.type)
+  end
+
+  test "destroy removes the category and its children" do
+    sign_in_as(@owner)
+    assert_difference -> { AllocationCategory.count }, -2 do
+      delete admin_allocation_category_path(@education)
+    end
+    assert_redirected_to admin_allocation_categories_path(type: @education.type)
+  end
+
+  test "cannot edit another organization's category" do
+    sign_in_as(@owner)
+    get edit_admin_allocation_category_path(allocation_categories(:boston_program))
+    assert_response :not_found
+  end
+
+  test "cannot destroy another organization's category" do
+    sign_in_as(@owner)
+    assert_no_difference -> { AllocationCategory.count } do
+      delete admin_allocation_category_path(allocation_categories(:boston_program))
+    end
+    assert_response :not_found
+  end
+end

--- a/test/fixtures/allocation_categories.yml
+++ b/test/fixtures/allocation_categories.yml
@@ -13,3 +13,8 @@ population_youth:
   organization: arlington
   type: AllocationCategory::Population
   name: Children and Youth
+
+boston_program:
+  organization: boston
+  type: AllocationCategory::Program
+  name: Boston Arts


### PR DESCRIPTION
Adds an org-admin-only page (linked from the admin dashboard via a "Manage categories" button) to create, update, and delete allocation categories, gated by the existing `Admin::ApplicationController` auth and scoped to the current organization. Categories are displayed in type tabs (Program / Population / Organization) with parent→child nesting, and the active tab is preserved across new/edit/cancel/save through a `type` query param. A small generic `tabs` Stimulus controller drives the tabs and a `typed-link` controller keeps the "New category" link's type in sync with the selected tab. The model gains an STI `type` inclusion validation and a parent-must-match-org-and-type validation, and a parent picker excludes a category's own descendants to avoid cycles. Covered by a new controller test and a Boston fixture verifying CRUD, authorization, org isolation, and tab behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)