### PR TITLE
Link user names in admin scenarios dashboard to filter by user

### DIFF
--- a/app/views/admin/scenarios/index.html.erb
+++ b/app/views/admin/scenarios/index.html.erb
@@ -28,7 +28,12 @@
         <tbody class="divide-y divide-line-soft">
           <% @scenarios.each do |scenario| %>
             <tr class="bg-surface hover:bg-surface-soft transition">
-              <td class="px-4 py-2.5 font-medium text-ink"><%= scenario.user.display_name %></td>
+              <td class="px-4 py-2.5 font-medium">
+                <%= link_to scenario.user.display_name,
+                      admin_scenarios_path(q: scenario.user.email_address),
+                      data: { turbo_frame: "_top" },
+                      class: "text-ink hover:text-ink-soft hover:underline" %>
+              </td>
               <td class="px-4 py-2.5 text-ink-soft"><%= scenario.name %></td>
               <td class="px-4 py-2.5 text-right tabular-nums text-ink">
                 <%= scenario.total_giving_amount.present? ? number_to_currency(scenario.total_giving_amount, precision: 0) : content_tag(:span, "—", class: "text-ink-faint") %>


### PR DESCRIPTION
Clicking a user's name in the admin scenarios dashboard now filters the list down to just that user's scenarios. The link reuses the existing `q` search param, matching on the user's unique email address so the result is unambiguous and the search box reflects the active filter. A full-page (`_top`) navigation keeps the outer search input in sync with the applied filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)