### PR TITLE
Let org admins view and edit any scenario in their organization

### DIFF
--- a/app/controllers/allocations_controller.rb
+++ b/app/controllers/allocations_controller.rb
@@ -1,4 +1,6 @@
 class AllocationsController < ApplicationController
+  include ScenarioScoping
+
   before_action :set_scenario
 
   def create
@@ -27,7 +29,7 @@ class AllocationsController < ApplicationController
   private
 
   def set_scenario
-    @scenario = Current.user.scenarios.where(organization: Current.organization).find(params[:scenario_id])
+    @scenario = accessible_scenarios.find(params[:scenario_id])
   end
 
   def allocation_params

--- a/app/controllers/concerns/scenario_scoping.rb
+++ b/app/controllers/concerns/scenario_scoping.rb
@@ -1,0 +1,21 @@
+module ScenarioScoping
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :viewing_on_behalf?
+  end
+
+  private
+
+  def accessible_scenarios
+    Current.organization_membership&.accessible_scenarios || owned_scenarios
+  end
+
+  def owned_scenarios
+    Current.user.scenarios.where(organization: Current.organization)
+  end
+
+  def viewing_on_behalf?(scenario)
+    scenario.present? && scenario.user_id != Current.user.id
+  end
+end

--- a/app/controllers/scenarios/names_controller.rb
+++ b/app/controllers/scenarios/names_controller.rb
@@ -1,4 +1,6 @@
 class Scenarios::NamesController < ApplicationController
+  include ScenarioScoping
+
   before_action :set_scenario
 
   def show
@@ -18,7 +20,7 @@ class Scenarios::NamesController < ApplicationController
   private
 
   def set_scenario
-    @scenario = Current.user.scenarios.where(organization: Current.organization).find(params[:scenario_id])
+    @scenario = accessible_scenarios.find(params[:scenario_id])
   end
 
   def name_params

--- a/app/controllers/scenarios/total_giving_amounts_controller.rb
+++ b/app/controllers/scenarios/total_giving_amounts_controller.rb
@@ -1,4 +1,6 @@
 class Scenarios::TotalGivingAmountsController < ApplicationController
+  include ScenarioScoping
+
   before_action :set_scenario
 
   def show
@@ -18,7 +20,7 @@ class Scenarios::TotalGivingAmountsController < ApplicationController
   private
 
   def set_scenario
-    @scenario = Current.user.scenarios.where(organization: Current.organization).find(params[:scenario_id])
+    @scenario = accessible_scenarios.find(params[:scenario_id])
   end
 
   def total_giving_amount_params

--- a/app/controllers/scenarios_controller.rb
+++ b/app/controllers/scenarios_controller.rb
@@ -1,19 +1,21 @@
 class ScenariosController < ApplicationController
+  include ScenarioScoping
+
   before_action :set_scenario, only: %i[ show update destroy ]
 
   def index
-    @scenarios = scenarios.order(created_at: :desc)
+    @scenarios = owned_scenarios.order(created_at: :desc)
   end
 
   def show
   end
 
   def new
-    @scenario = scenarios.new
+    @scenario = owned_scenarios.new
   end
 
   def create
-    @scenario = scenarios.new(scenario_params)
+    @scenario = owned_scenarios.new(scenario_params)
     if @scenario.save
       redirect_to scenario_path(@scenario)
     else
@@ -30,18 +32,15 @@ class ScenariosController < ApplicationController
   end
 
   def destroy
+    on_behalf = viewing_on_behalf?(@scenario)
     @scenario.destroy
-    redirect_to scenarios_path
+    redirect_to on_behalf ? admin_scenarios_path : scenarios_path
   end
 
   private
 
-  def scenarios
-    Current.user.scenarios.where(organization: Current.organization)
-  end
-
   def set_scenario
-    @scenario = scenarios.find(params[:id])
+    @scenario = accessible_scenarios.find(params[:id])
   end
 
   def scenario_params

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -2,4 +2,8 @@ class Current < ActiveSupport::CurrentAttributes
   attribute :session
   attribute :organization
   delegate :user, to: :session, allow_nil: true
+
+  def organization_membership
+    user&.membership_in(organization)
+  end
 end

--- a/app/models/organization_membership.rb
+++ b/app/models/organization_membership.rb
@@ -6,4 +6,16 @@ class OrganizationMembership < ApplicationRecord
 
   validates :user_id, uniqueness: { scope: :organization_id }
   validates :role, presence: true
+
+  def accessible_scenarios
+    if admin? || owner?
+      organization.scenarios
+    else
+      owned_scenarios
+    end
+  end
+
+  def owned_scenarios
+    user.scenarios.where(organization: organization)
+  end
 end

--- a/app/views/admin/scenarios/index.html.erb
+++ b/app/views/admin/scenarios/index.html.erb
@@ -32,10 +32,16 @@
         <tbody class="divide-y divide-line-soft">
           <% @scenarios.each do |scenario| %>
             <tr class="bg-surface hover:bg-surface-soft transition">
-              <td class="px-4 py-2.5 font-medium text-ink"><%= scenario.user.display_name %></td>
-              <td class="px-4 py-2.5 text-ink-soft"><%= scenario.name %></td>
+              <td class="px-4 py-2.5 font-medium text-ink">
+                <%= link_to scenario.user.display_name, scenario_path(scenario), data: { turbo_frame: "_top" }, class: "block hover:underline" %>
+              </td>
+              <td class="px-4 py-2.5 text-ink-soft">
+                <%= link_to scenario.name, scenario_path(scenario), data: { turbo_frame: "_top" }, class: "block hover:underline" %>
+              </td>
               <td class="px-4 py-2.5 text-right tabular-nums text-ink">
-                <%= scenario.total_giving_amount.present? ? number_to_currency(scenario.total_giving_amount, precision: 0) : content_tag(:span, "—", class: "text-ink-faint") %>
+                <%= link_to scenario_path(scenario), data: { turbo_frame: "_top" }, class: "block" do %>
+                  <%= scenario.total_giving_amount.present? ? number_to_currency(scenario.total_giving_amount, precision: 0) : content_tag(:span, "—", class: "text-ink-faint") %>
+                <% end %>
               </td>
             </tr>
           <% end %>

--- a/app/views/scenarios/show.html.erb
+++ b/app/views/scenarios/show.html.erb
@@ -1,6 +1,17 @@
 <div class="mx-auto max-w-5xl w-full px-4 py-10">
-  <%= link_to "← Back to explore options", scenarios_path,
-        class: "inline-block rounded-md border border-line bg-surface px-3 py-1.5 text-sm text-ink-soft hover:bg-canvas transition" %>
+  <% if viewing_on_behalf?(@scenario) %>
+    <%= link_to "← Back to all scenarios", admin_scenarios_path,
+          class: "inline-block rounded-md border border-line bg-surface px-3 py-1.5 text-sm text-ink-soft hover:bg-canvas transition" %>
+  <% else %>
+    <%= link_to "← Back to explore options", scenarios_path,
+          class: "inline-block rounded-md border border-line bg-surface px-3 py-1.5 text-sm text-ink-soft hover:bg-canvas transition" %>
+  <% end %>
+
+  <% if viewing_on_behalf?(@scenario) %>
+    <div class="mt-4 rounded-md border border-line bg-surface-soft px-4 py-2.5 text-sm text-ink-soft">
+      Viewing <span class="font-medium text-ink"><%= @scenario.user.display_name %></span>'s scenario as an admin. Changes you make are saved to their account.
+    </div>
+  <% end %>
 
   <%= render "scenarios/names/name", scenario: @scenario %>
 

--- a/test/controllers/admin/scenarios_controller_test.rb
+++ b/test/controllers/admin/scenarios_controller_test.rb
@@ -34,6 +34,15 @@ class Admin::ScenariosControllerTest < ActionDispatch::IntegrationTest
     assert_select "td", text: @admin.display_name
   end
 
+  test "rows link to the scenario and break out of the table turbo frame" do
+    sign_in_as(@owner)
+    get admin_scenarios_path
+
+    # data-turbo-frame="_top" is required so the link navigates the whole page
+    # instead of trying (and failing) to render into the scenarios_table frame.
+    assert_select "a[href=?][data-turbo-frame=_top]", scenario_path(scenarios(:one_arlington))
+  end
+
   test "does not show scenarios from another organization" do
     sign_in_as(@owner)
     get admin_scenarios_path

--- a/test/controllers/allocations_controller_test.rb
+++ b/test/controllers/allocations_controller_test.rb
@@ -103,4 +103,32 @@ class AllocationsControllerTest < ActionDispatch::IntegrationTest
     end
     assert_response :not_found
   end
+
+  test "admin can add an allocation to another user's scenario in the same org" do
+    sign_in_as users(:admin)
+    assert_difference -> { @scenario.allocations.count }, 1 do
+      post scenario_allocations_url(@scenario), params: {
+        allocation: { type: "Allocation::Ongoing", option: "Population: Youth", percentage: 25 }
+      }
+    end
+    assert_redirected_to scenario_path(@scenario)
+  end
+
+  test "admin can destroy an allocation on another user's scenario in the same org" do
+    sign_in_as users(:admin)
+    assert_difference -> { @scenario.allocations.count }, -1 do
+      delete scenario_allocation_url(@scenario, allocations(:greatest_need))
+    end
+    assert_redirected_to scenario_path(@scenario)
+  end
+
+  test "plain member cannot add an allocation to another user's scenario in the same org" do
+    sign_in_as users(:passwordless)
+    assert_no_difference -> { Allocation.count } do
+      post scenario_allocations_url(@scenario), params: {
+        allocation: { type: "Allocation::Ongoing", option: "X", percentage: 10 }
+      }
+    end
+    assert_response :not_found
+  end
 end

--- a/test/controllers/scenarios/names_controller_test.rb
+++ b/test/controllers/scenarios/names_controller_test.rb
@@ -35,4 +35,20 @@ class Scenarios::NamesControllerTest < ActionDispatch::IntegrationTest
     get edit_scenario_name_url(scenarios(:two_boston))
     assert_response :not_found
   end
+
+  test "admin can edit another user's scenario name in the same org" do
+    sign_in_as users(:admin)
+    get edit_scenario_name_url(@scenario)
+    assert_response :success
+
+    patch scenario_name_url(@scenario), params: { scenario: { name: "Admin renamed" } }
+    assert_response :success
+    assert_equal "Admin renamed", @scenario.reload.name
+  end
+
+  test "plain member cannot edit another user's scenario name in the same org" do
+    sign_in_as users(:passwordless)
+    get edit_scenario_name_url(@scenario)
+    assert_response :not_found
+  end
 end

--- a/test/controllers/scenarios/total_giving_amounts_controller_test.rb
+++ b/test/controllers/scenarios/total_giving_amounts_controller_test.rb
@@ -29,4 +29,20 @@ class Scenarios::TotalGivingAmountsControllerTest < ActionDispatch::IntegrationT
     get edit_scenario_total_giving_amount_url(scenarios(:two_boston))
     assert_response :not_found
   end
+
+  test "admin can edit another user's scenario total in the same org" do
+    sign_in_as users(:admin)
+    get edit_scenario_total_giving_amount_url(@scenario)
+    assert_response :success
+
+    patch scenario_total_giving_amount_url(@scenario), params: { scenario: { total_giving_amount: 7500 } }
+    assert_response :success
+    assert_equal 7500, @scenario.reload.total_giving_amount
+  end
+
+  test "plain member cannot edit another user's scenario total in the same org" do
+    sign_in_as users(:passwordless)
+    get edit_scenario_total_giving_amount_url(@scenario)
+    assert_response :not_found
+  end
 end

--- a/test/controllers/scenarios_controller_test.rb
+++ b/test/controllers/scenarios_controller_test.rb
@@ -63,4 +63,45 @@ class ScenariosControllerTest < ActionDispatch::IntegrationTest
     get scenario_url(scenarios(:two_boston))
     assert_response :not_found
   end
+
+  test "admin can view another user's scenario in the same org" do
+    sign_in_as users(:admin)
+    get scenario_url(scenarios(:one_arlington))
+    assert_response :success
+    assert_select "a[href=?]", admin_scenarios_path
+    assert_match "as an admin", response.body
+  end
+
+  test "admin can update another user's scenario" do
+    sign_in_as users(:admin)
+    patch scenario_url(scenarios(:one_arlington)), params: { scenario: { total_giving_amount: 999 } }
+    assert_equal 999, scenarios(:one_arlington).reload.total_giving_amount
+  end
+
+  test "admin destroy of another user's scenario returns to the admin dashboard" do
+    sign_in_as users(:admin)
+    assert_difference -> { Scenario.count }, -1 do
+      delete scenario_url(scenarios(:one_arlington))
+    end
+    assert_redirected_to admin_scenarios_path
+  end
+
+  test "admin still cannot reach a scenario in another org" do
+    sign_in_as users(:admin)
+    get scenario_url(scenarios(:two_boston))
+    assert_response :not_found
+  end
+
+  test "plain member cannot reach another user's scenario in the same org" do
+    sign_in_as users(:passwordless)
+    get scenario_url(scenarios(:one_arlington))
+    assert_response :not_found
+  end
+
+  test "super admin cannot change another user's scenario" do
+    sign_in_as users(:super_admin)
+    patch scenario_url(scenarios(:one_arlington)), params: { scenario: { total_giving_amount: 1 } }
+    assert_response :not_found
+    assert_equal 10000, scenarios(:one_arlington).reload.total_giving_amount
+  end
 end

--- a/test/models/organization_membership_test.rb
+++ b/test/models/organization_membership_test.rb
@@ -37,4 +37,24 @@ class OrganizationMembershipTest < ActiveSupport::TestCase
     assert_not membership.valid?
     assert_includes membership.errors[:role], "can't be blank"
   end
+
+  test "owned_scenarios are the member's own scenarios in the organization" do
+    membership = organization_memberships(:one_arlington)
+    assert_includes membership.owned_scenarios, scenarios(:one_arlington)
+    assert_not_includes membership.owned_scenarios, scenarios(:admin_arlington)
+  end
+
+  test "admins and owners can access any scenario in the organization" do
+    %i[ admin_arlington one_arlington ].each do |fixture|
+      membership = organization_memberships(fixture)
+      assert_includes membership.accessible_scenarios, scenarios(:one_arlington)
+      assert_includes membership.accessible_scenarios, scenarios(:admin_arlington)
+    end
+  end
+
+  test "plain members can only access their own scenarios" do
+    membership = organization_memberships(:passwordless_arlington)
+    assert_equal membership.owned_scenarios.to_a, membership.accessible_scenarios.to_a
+    assert_not_includes membership.accessible_scenarios, scenarios(:one_arlington)
+  end
 end


### PR DESCRIPTION
Admins and owners can now open any scenario in their organization from the admin scenarios dashboard (rows are now links) and use the existing scenario UI to view, edit, and delete it. Access is resolved through the user's org membership via a new `ScenarioScoping` concern and `OrganizationMembership#accessible_scenarios`/`owned_scenarios`: admins/owners get org-wide access while everyone else — including super admins, who have no membership — is limited to their own scenarios. When an admin views another user's scenario, the show page displays an "on behalf of" banner and a back-link to the dashboard. Added controller and model test coverage, including regression guards that plain members and super admins cannot reach or change other users' scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)