### PR TITLE
Add admin dashboard landing page

### DIFF
--- a/app/controllers/admin/dashboards_controller.rb
+++ b/app/controllers/admin/dashboards_controller.rb
@@ -1,0 +1,4 @@
+class Admin::DashboardsController < Admin::ApplicationController
+  def show
+  end
+end

--- a/app/views/admin/allocation_categories/index.html.erb
+++ b/app/views/admin/allocation_categories/index.html.erb
@@ -12,8 +12,6 @@
       <h1 class="mt-1 text-2xl font-semibold tracking-tight text-ink">Allocation categories</h1>
     </div>
     <div class="flex items-center gap-3">
-      <%= link_to "← Dashboard", admin_scenarios_path,
-            class: "rounded border border-line px-2.5 py-1.5 text-sm text-ink-soft hover:bg-surface-soft hover:text-ink" %>
       <%= link_to "New category", new_admin_allocation_category_path,
             data: { controller: "typed-link", action: "tabs:change@window->typed-link#update",
                     typed_link_base_path_value: new_admin_allocation_category_path,

--- a/app/views/admin/dashboards/show.html.erb
+++ b/app/views/admin/dashboards/show.html.erb
@@ -1,0 +1,24 @@
+<% content_for :title, "Dashboard" %>
+
+<div class="mx-auto max-w-6xl w-full px-6 py-10">
+  <div class="flex flex-wrap items-end justify-between gap-4 border-b border-line pb-5">
+    <div>
+      <p class="text-xs font-semibold uppercase tracking-wider text-ink-faint">Admin</p>
+      <h1 class="mt-1 text-2xl font-semibold tracking-tight text-ink">Dashboard</h1>
+    </div>
+  </div>
+
+  <div class="mt-6 grid gap-4 sm:grid-cols-2">
+    <%= link_to admin_scenarios_path,
+          class: "block rounded-lg border border-line bg-surface p-5 hover:bg-surface-soft transition" do %>
+      <h2 class="text-lg font-semibold text-ink">Scenarios</h2>
+      <p class="mt-1 text-sm text-ink-soft">View and manage scenarios across the organization.</p>
+    <% end %>
+
+    <%= link_to admin_allocation_categories_path,
+          class: "block rounded-lg border border-line bg-surface p-5 hover:bg-surface-soft transition" do %>
+      <h2 class="text-lg font-semibold text-ink">Allocation categories</h2>
+      <p class="mt-1 text-sm text-ink-soft">Manage the categories used in allocations.</p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/scenarios/index.html.erb
+++ b/app/views/admin/scenarios/index.html.erb
@@ -7,8 +7,6 @@
       <h1 class="mt-1 text-2xl font-semibold tracking-tight text-ink">Scenarios</h1>
     </div>
     <div class="flex items-center gap-3">
-      <%= link_to "Manage categories", admin_allocation_categories_path,
-            class: "rounded border border-line px-2.5 py-1.5 text-sm text-ink-soft hover:bg-surface-soft hover:text-ink" %>
       <%= form_with url: admin_scenarios_path, method: :get,
             data: { controller: "debounced-form", action: "input->debounced-form#submit",
                     turbo_frame: "scenarios_table", turbo_action: "advance" } do |form| %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,7 +43,7 @@
         <% if authenticated? %>
           <%= link_to "Explore options", scenarios_path, class: "text-ink-soft hover:text-ink" %>
           <% if Current.user&.admin_of?(Current.organization) %>
-            <%= link_to "Admin Dashboard", admin_scenarios_path, class: "text-ink-soft hover:text-ink" %>
+            <%= link_to "Admin Dashboard", admin_dashboard_path, class: "text-ink-soft hover:text-ink" %>
             <%= link_to "Members", organization_memberships_path, class: "text-ink-soft hover:text-ink" %>
           <% end %>
           <%= link_to "Profile", users_profile_path, class: "text-ink-soft hover:text-ink" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
   end
 
   namespace :admin do
+    resource :dashboard, only: :show
     resources :scenarios, only: :index
     resources :allocation_categories, only: %i[ index new create edit update destroy ]
   end


### PR DESCRIPTION
Adds an `/admin/dashboard` landing page with cards linking to the admin scenarios and allocation categories pages. The new `Admin::DashboardsController#show` inherits the existing `require_admin` authorization. The navbar's "Admin Dashboard" link now points to this page instead of directly to scenarios, and the now-redundant cross-links between the scenarios and categories pages have been removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)