### PR TITLE
Show dollar amounts in the allocation summary

### DIFF
--- a/app/models/allocation/ongoing.rb
+++ b/app/models/allocation/ongoing.rb
@@ -3,6 +3,10 @@ class Allocation::Ongoing < Allocation
     presence: true,
     numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 100 }
 
+  def dollar_amount
+    (percentage.to_i / 100.0 * scenario.ongoing_giving_amount).round
+  end
+
   def ongoing?
     true
   end

--- a/app/models/scenario.rb
+++ b/app/models/scenario.rb
@@ -10,4 +10,12 @@ class Scenario < ApplicationRecord
   def ongoing_percentage_total
     ongoing_allocations.sum { |allocation| allocation.percentage.to_i }
   end
+
+  def one_time_giving_amount
+    one_time_allocations.sum { |allocation| allocation.amount.to_i }
+  end
+
+  def ongoing_giving_amount
+    total_giving_amount.to_i - one_time_giving_amount
+  end
 end

--- a/app/views/scenarios/show.html.erb
+++ b/app/views/scenarios/show.html.erb
@@ -43,12 +43,16 @@
 
       <div class="mt-5">
         <h3 class="text-[11px] font-semibold uppercase tracking-wide text-ink-faint">On going giving</h3>
+        <p class="mt-1 font-serif text-2xl font-medium text-ink"><%= number_to_currency(@scenario.ongoing_giving_amount, precision: 0) %></p>
         <% if @scenario.ongoing_allocations.any? %>
           <ul class="mt-3 space-y-2">
             <% @scenario.ongoing_allocations.each do |allocation| %>
               <li class="flex justify-between text-ink-soft">
                 <span><%= allocation.display_label %></span>
-                <span class="font-medium text-ink"><%= allocation.percentage %>%</span>
+                <span class="flex items-baseline gap-3">
+                  <span class="font-medium text-ink"><%= allocation.percentage %>%</span>
+                  <span class="text-ink-soft"><%= number_to_currency(allocation.dollar_amount, precision: 0) %></span>
+                </span>
               </li>
             <% end %>
           </ul>

--- a/test/models/allocation_test.rb
+++ b/test/models/allocation_test.rb
@@ -42,6 +42,11 @@ class AllocationTest < ActiveSupport::TestCase
     assert @scenario.one_time_allocations.new(option: "Just fits", amount: 5000).valid?
   end
 
+  test "ongoing dollar_amount is its percentage of the scenario's ongoing giving" do
+    # scenario ongoing giving is 10000 total - 5000 one-time = 5000; greatest_need is 30%.
+    assert_equal 1500, allocations(:greatest_need).dollar_amount
+  end
+
   test "kind predicates reflect the subclass" do
     assert allocations(:greatest_need).ongoing?
     assert_not allocations(:greatest_need).one_time?

--- a/test/models/scenario_test.rb
+++ b/test/models/scenario_test.rb
@@ -17,6 +17,19 @@ class ScenarioTest < ActiveSupport::TestCase
     assert_equal 30, scenarios(:one_arlington).ongoing_percentage_total
   end
 
+  test "one_time_giving_amount sums one-time allocation amounts" do
+    assert_equal 5000, scenarios(:one_arlington).one_time_giving_amount
+  end
+
+  test "ongoing_giving_amount is total giving minus one-time gifts" do
+    assert_equal 5000, scenarios(:one_arlington).ongoing_giving_amount
+  end
+
+  test "ongoing_giving_amount treats a missing total as zero" do
+    scenario = Scenario.new
+    assert_equal 0, scenario.ongoing_giving_amount
+  end
+
   test "destroys dependent allocations" do
     scenario = scenarios(:one_arlington)
     assert_difference -> { Allocation.count }, -2 do


### PR DESCRIPTION
The allocation summary now shows real dollar figures alongside percentages. Each ongoing allocation row displays its dollar amount next to its percent (e.g. `30%  $1,500`), and the "On going giving" section shows a dollar total defined as the total giving amount minus one-time gifts. New `Scenario#ongoing_giving_amount`/`#one_time_giving_amount` and `Allocation::Ongoing#dollar_amount` helpers back the view, with model tests covering the calculations (including a missing-total-as-zero case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)