### PR TITLE
Declutter nav bar with a user menu dropdown

### DIFF
--- a/app/javascript/controllers/dropdown_controller.js
+++ b/app/javascript/controllers/dropdown_controller.js
@@ -1,0 +1,23 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["menu", "trigger"]
+
+  toggle() {
+    this.menuTarget.classList.contains("hidden") ? this.open() : this.close()
+  }
+
+  open() {
+    this.menuTarget.classList.remove("hidden")
+    if (this.hasTriggerTarget) this.triggerTarget.setAttribute("aria-expanded", "true")
+  }
+
+  close() {
+    this.menuTarget.classList.add("hidden")
+    if (this.hasTriggerTarget) this.triggerTarget.setAttribute("aria-expanded", "false")
+  }
+
+  closeOnOutsideClick(event) {
+    if (!this.element.contains(event.target)) this.close()
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,17 +37,30 @@
       <% end %>
 
       <div class="ml-auto flex items-center gap-4 text-sm">
-        <% if Rails.env.development? %>
-          <%= link_to "Mailer previews", "/rails/mailers", class: "text-ink-soft hover:text-ink" %>
-        <% end %>
         <% if authenticated? %>
-          <%= link_to "About you", users_story_path, class: "text-ink-soft hover:text-ink" %>
-          <%= link_to "Explore options", scenarios_path, class: "text-ink-soft hover:text-ink" %>
-          <% if Current.user&.admin_of?(Current.organization) %>
-            <%= link_to "Admin Dashboard", admin_dashboard_path, class: "text-ink-soft hover:text-ink" %>
-          <% end %>
-          <%= link_to "Profile", users_profile_path, class: "text-ink-soft hover:text-ink" %>
-          <%= button_to "Sign out", session_path, method: :delete, class: "text-ink-soft hover:text-ink cursor-pointer" %>
+          <%= link_to "Dashboard", dashboard_path, class: "text-ink-soft hover:text-ink" %>
+          <div class="relative" data-controller="dropdown"
+               data-action="click@window->dropdown#closeOnOutsideClick keydown.esc->dropdown#close">
+            <button type="button" data-action="dropdown#toggle" data-dropdown-target="trigger"
+                    aria-haspopup="true" aria-expanded="false"
+                    class="flex items-center gap-1 text-ink-soft hover:text-ink cursor-pointer">
+              <%= Current.user&.name.presence || Current.user&.email_address %>
+              <svg class="h-4 w-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" aria-hidden="true">
+                <path d="M6 8l4 4 4-4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+              </svg>
+            </button>
+            <div data-dropdown-target="menu"
+                 class="hidden absolute right-0 top-full mt-2 w-48 rounded-md border border-line bg-surface py-1 shadow-lg">
+              <%= link_to "Profile", users_profile_path, class: "block px-4 py-2 text-ink-soft hover:text-ink hover:bg-canvas" %>
+              <% if Current.user&.admin_of?(Current.organization) %>
+                <%= link_to "Admin Dashboard", admin_dashboard_path, class: "block px-4 py-2 text-ink-soft hover:text-ink hover:bg-canvas" %>
+              <% end %>
+              <% if Rails.env.development? %>
+                <%= link_to "Mailer previews", "/rails/mailers", class: "block px-4 py-2 text-ink-soft hover:text-ink hover:bg-canvas" %>
+              <% end %>
+              <%= button_to "Sign out", session_path, method: :delete, class: "block w-full text-left px-4 py-2 text-ink-soft hover:text-ink hover:bg-canvas cursor-pointer" %>
+            </div>
+          </div>
         <% elsif Current.organization %>
           <%= link_to "Log in", new_session_path, class: "text-ink-soft hover:text-ink" %>
           <%= link_to "Explore the legacy builder platform", new_registration_path,

--- a/test/controllers/dashboards_controller_test.rb
+++ b/test/controllers/dashboards_controller_test.rb
@@ -13,8 +13,8 @@ class DashboardsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "h1", "Welcome to your workspace"
-    assert_select "a[href=?]", users_story_path, text: "About you"
-    assert_select "a[href=?]", scenarios_path, text: "Explore options"
+    assert_select "a[href=?] h3", users_story_path, text: "About you"
+    assert_select "a[href=?] h3", scenarios_path, text: "Explore options"
     # The nav brand/logo links back to the dashboard for signed-in users.
     assert_select "nav a[href=?]", dashboard_path
   end


### PR DESCRIPTION
Collapses the signed-in nav from a flat row of links into a single top-level **Dashboard** link plus a user-name dropdown in the top-right corner. The dropdown holds **Profile**, **Admin Dashboard** (admins only), **Mailer previews** (dev only), and **Sign out**, and is driven by a new lightweight `dropdown` Stimulus controller that dismisses on outside-click and Escape. About you and Explore options are dropped from the nav since both are reachable from their cards on the Dashboard. The dashboard controller test's link assertions are retargeted at the dashboard cards (`a[href] h3`) rather than the old plain-text nav links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)