### PR TITLE
Strip HTTP Basic-Auth credentials from the URL

### DIFF
--- a/app/javascript/controllers/strip_url_credentials_controller.js
+++ b/app/javascript/controllers/strip_url_credentials_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Strips HTTP Basic-Auth credentials from the URL (e.g. https://user:pass@host).
+// The user:pass@ form makes document.URL mismatch the credential-free URL Turbo
+// passes to history.replaceState(), throwing a SecurityError that breaks the page.
+// The browser has already cached the credentials, so the clean navigation below
+// stays authenticated.
+export default class extends Controller {
+  connect() {
+    const url = new URL(window.location.href)
+    if (url.username || url.password) {
+      url.username = ""
+      url.password = ""
+      window.location.replace(url.toString())
+    }
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,7 +27,7 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body class="min-h-screen bg-canvas">
+  <body class="min-h-screen bg-canvas" data-controller="strip-url-credentials">
     <nav class="sticky top-0 z-50 flex h-13 items-center border-b border-line bg-surface px-6 sm:px-9">
       <%= link_to(authenticated? ? dashboard_path : root_path, class: "flex items-center gap-2 font-serif text-lg tracking-tight text-ink hover:text-ink") do %>
         <% if Current.organization&.logo&.attached? %>


### PR DESCRIPTION
Loading production behind the pre-release Basic-Auth lock via a credentialed URL (`https://user:pass@host`) leaves the credentials in `document.URL`, so when Turbo calls `history.replaceState()` with the credential-free URL the browser throws a `SecurityError` that cascades and breaks login. This adds a `strip-url-credentials` Stimulus controller on `<body>` that detects credentials in `location` and redirects to the clean URL; the browser has already cached the auth, so the navigation stays authenticated and Turbo works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)