### PR TITLE
Do not allow decimals in frontend when changing giving amount in a scenario

### DIFF
--- a/app/javascript/controllers/integer_input_controller.js
+++ b/app/javascript/controllers/integer_input_controller.js
@@ -3,11 +3,58 @@ import { Controller } from "@hotwired/stimulus"
 // The app primarily accepts values in whole dollar amounts only (no cents),
 // So we do not allow cents from being submitted in the UI.
 export default class extends Controller {
+  static values = { invalidMessage: { type: String, default: "Whole numbers only" } }
+
+  connect() {
+    this.element.addEventListener("keydown", this.rejectInvalidKey)
+    this.element.addEventListener("paste", this.rejectInvalidPaste)
+  }
+
+  disconnect() {
+    this.element.removeEventListener("keydown", this.rejectInvalidKey)
+    this.element.removeEventListener("paste", this.rejectInvalidPaste)
+    this.clearCustomValidity()
+  }
+
+  rejectInvalidKey = (event) => {
+    if (event.ctrlKey || event.metaKey || event.altKey) return
+    if (event.key.length > 1) return
+    if (/\D/.test(event.key)) {
+      event.preventDefault()
+      this.reportError()
+    }
+  }
+
+  rejectInvalidPaste = (event) => {
+    const text = event.clipboardData.getData("text")
+    if (/\D/.test(text)) {
+      event.preventDefault()
+      this.reportError()
+    }
+  }
+
   transform() {
     const value = this.element.value
     const sanitized = value.replace(/\D/g, "")
     if (value !== sanitized) {
       this.element.value = sanitized
+      this.reportError()
+    } else {
+      this.clearCustomValidity()
+    }
+  }
+
+  reportError() {
+    const input = this.element
+    if (input.setCustomValidity) {
+      input.setCustomValidity(this.invalidMessageValue)
+      input.reportValidity()
+    }
+  }
+
+  clearCustomValidity() {
+    if (this.element.setCustomValidity) {
+      this.element.setCustomValidity("")
     }
   }
 }

--- a/app/javascript/controllers/integer_input_controller.js
+++ b/app/javascript/controllers/integer_input_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from "@hotwired/stimulus"
+
+// The app primarily accepts values in whole dollar amounts only (no cents),
+// So we do not allow cents from being submitted in the UI.
+export default class extends Controller {
+  transform() {
+    const value = this.element.value
+    const sanitized = value.replace(/\D/g, "")
+    if (value !== sanitized) {
+      this.element.value = sanitized
+    }
+  }
+}

--- a/app/views/scenarios/_allocation_modal.html.erb
+++ b/app/views/scenarios/_allocation_modal.html.erb
@@ -31,6 +31,8 @@
         <div class="relative mt-1">
           <span class="absolute left-3 top-1/2 -translate-y-1/2 text-ink-faint">$</span>
           <%= number_field_tag "allocation[amount]", allocation.amount, id: "allocation_amount_#{suffix}", min: 0, step: "1", required: true, placeholder: "0",
+                inputmode: "numeric",
+                data: { controller: "integer-input", action: "input->integer-input#transform" },
                 class: "block w-full rounded-md border border-line bg-surface pl-7 pr-3 py-2 shadow-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
         </div>
       </div>

--- a/app/views/scenarios/total_giving_amounts/_form.html.erb
+++ b/app/views/scenarios/total_giving_amounts/_form.html.erb
@@ -6,6 +6,8 @@
       <div class="relative max-w-md w-full">
         <span class="absolute left-3 top-1/2 -translate-y-1/2 text-ink-faint">$</span>
         <%= form.number_field :total_giving_amount, step: "1", min: 0, autofocus: true, placeholder: "0",
+              inputmode: "numeric",
+              data: { controller: "integer-input", action: "input->integer-input#transform" },
               class: "block w-full rounded-md border border-line bg-surface-soft pl-7 pr-3 py-2 shadow-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/10" %>
       </div>
 


### PR DESCRIPTION
Yes, an error message shows up if a user tries to type in `12.34`, but we can go further with this number field and prevent decimals in general when typing it into the field.



https://github.com/user-attachments/assets/562b648c-145e-469a-a5fe-00a78695c71f


