### PR TITLE
Disable slider for total allocation

### DIFF
--- a/app/assets/tailwind/allocation_slider.css
+++ b/app/assets/tailwind/allocation_slider.css
@@ -8,21 +8,57 @@
     background: transparent;
     cursor: pointer;
 
+    --slider-thumb: 1rem;
     --slider-tick: var(--color-ink);
     --slider-blocked: var(--color-line);
     --slider-hatch: var(--color-ink-faint);
 
+    /* A native thumb's center travels between thumb/2 and width - thumb/2, not
+       0 and width. Anything painted on the track that has to line up with the
+       thumb — the fill's leading edge, the limit tick — must be positioned in
+       that same inset space, or the two drift apart everywhere except 50% and
+       the thumb visibly crosses the line it is supposed to stop at.
+       --slider-value and --slider-limit are unitless numbers (0-100) so they
+       can be scaled into that space here. */
+    --slider-value-pos: calc(
+      var(--slider-thumb) / 2 +
+      var(--slider-value, 0) * (100% - var(--slider-thumb)) / 100
+    );
+    --slider-limit-pos: calc(
+      var(--slider-thumb) / 2 +
+      var(--slider-limit, 100) * (100% - var(--slider-thumb)) / 100
+    );
+
+    --slider-track-image:
+      linear-gradient(
+        to right,
+        var(--slider-color) 0 var(--slider-value-pos),
+        var(--color-line-soft) 0
+      );
+    --slider-track-size: auto;
+    --slider-track-position: 0 0;
+  }
+
+  /* Only when headroom is actually short of 100% is there a boundary to draw;
+     otherwise the tick would float half a thumb in from the right end. */
+  .allocation-slider--capped {
     /* Three layers, painted top to bottom:
-       1. a 2px tick marking the limit (positioned by background-position, whose
-          percentage resolves against track width minus the tick, so it stays
-          flush inside the track at both 0% and 100%).
+       1. a 2px tick marking the limit, drawn as hard gradient stops rather than
+          a positioned layer so it shares the calc above (background-position
+          percentages resolve against track width minus image width, which is a
+          different space again).
        2. diagonal hatching over the blocked region only — sized to the leftover
-          width and pinned right, so it starts exactly at the limit. Texture,
+          width and pinned right, so it starts exactly at the tick. Texture,
           rather than a heavier color, is what reads as "unavailable": a darker
           band here looks like more allocation, not less headroom.
        3. the track itself: filled | available | blocked. */
     --slider-track-image:
-      linear-gradient(var(--slider-tick) 0 0),
+      linear-gradient(
+        to right,
+        transparent 0 calc(var(--slider-limit-pos) - 1px),
+        var(--slider-tick) 0 calc(var(--slider-limit-pos) + 1px),
+        transparent 0
+      ),
       repeating-linear-gradient(
         45deg,
         var(--slider-hatch) 0 1px,
@@ -30,15 +66,15 @@
       ),
       linear-gradient(
         to right,
-        var(--slider-color) 0 var(--slider-value, 0%),
-        var(--color-line-soft) 0 var(--slider-limit, 100%),
+        var(--slider-color) 0 var(--slider-value-pos),
+        var(--color-line-soft) 0 var(--slider-limit-pos),
         var(--slider-blocked) 0
       );
     --slider-track-size:
-      2px 100%,
-      calc(100% - var(--slider-limit, 100%)) 100%,
+      auto,
+      calc(100% - var(--slider-limit-pos)) 100%,
       auto;
-    --slider-track-position: var(--slider-limit, 100%) 0, 100% 0, 0 0;
+    --slider-track-position: 0 0, 100% 0, 0 0;
   }
 
   /* ::-webkit-slider-runnable-track and ::-moz-range-track can't be grouped —
@@ -56,8 +92,8 @@
   .allocation-slider::-webkit-slider-thumb {
     -webkit-appearance: none;
     appearance: none;
-    height: 1rem;
-    width: 1rem;
+    height: var(--slider-thumb);
+    width: var(--slider-thumb);
     margin-top: -0.25rem;
     border-radius: 9999px;
     background: var(--slider-color);
@@ -83,8 +119,8 @@
   }
 
   .allocation-slider::-moz-range-thumb {
-    height: 1rem;
-    width: 1rem;
+    height: var(--slider-thumb);
+    width: var(--slider-thumb);
     border: 2px solid var(--color-surface);
     border-radius: 9999px;
     background: var(--slider-color);

--- a/app/assets/tailwind/allocation_slider.css
+++ b/app/assets/tailwind/allocation_slider.css
@@ -7,18 +7,50 @@
     border-radius: 9999px;
     background: transparent;
     cursor: pointer;
+
+    --slider-tick: var(--color-ink);
+    --slider-blocked: var(--color-line);
+    --slider-hatch: var(--color-ink-faint);
+
+    /* Three layers, painted top to bottom:
+       1. a 2px tick marking the limit (positioned by background-position, whose
+          percentage resolves against track width minus the tick, so it stays
+          flush inside the track at both 0% and 100%).
+       2. diagonal hatching over the blocked region only — sized to the leftover
+          width and pinned right, so it starts exactly at the limit. Texture,
+          rather than a heavier color, is what reads as "unavailable": a darker
+          band here looks like more allocation, not less headroom.
+       3. the track itself: filled | available | blocked. */
+    --slider-track-image:
+      linear-gradient(var(--slider-tick) 0 0),
+      repeating-linear-gradient(
+        45deg,
+        var(--slider-hatch) 0 1px,
+        transparent 1px 4px
+      ),
+      linear-gradient(
+        to right,
+        var(--slider-color) 0 var(--slider-value, 0%),
+        var(--color-line-soft) 0 var(--slider-limit, 100%),
+        var(--slider-blocked) 0
+      );
+    --slider-track-size:
+      2px 100%,
+      calc(100% - var(--slider-limit, 100%)) 100%,
+      auto;
+    --slider-track-position: var(--slider-limit, 100%) 0, 100% 0, 0 0;
   }
 
+  /* ::-webkit-slider-runnable-track and ::-moz-range-track can't be grouped —
+     an unrecognized selector would invalidate the whole rule — but custom
+     properties inherit into pseudo-elements, so the value above is written once. */
   .allocation-slider::-webkit-slider-runnable-track {
     height: 0.5rem;
     border-radius: 9999px;
-    background: linear-gradient(
-      to right,
-      var(--slider-color) 0%,
-      var(--slider-color) var(--slider-value, 0%),
-      var(--color-line-soft) var(--slider-value, 0%),
-      var(--color-line-soft) 100%
-    );
+    background-image: var(--slider-track-image);
+    background-size: var(--slider-track-size);
+    background-position: var(--slider-track-position);
+    background-repeat: no-repeat;
   }
 
   .allocation-slider::-webkit-slider-thumb {
@@ -35,14 +67,19 @@
 
   .allocation-slider::-moz-range-track {
     height: 0.5rem;
+    border: none;
     border-radius: 9999px;
-    background: var(--color-line-soft);
+    background-image: var(--slider-track-image);
+    background-size: var(--slider-track-size);
+    background-position: var(--slider-track-position);
+    background-repeat: no-repeat;
   }
 
+  /* Firefox paints its own fill over the track; ours is already in the gradient. */
   .allocation-slider::-moz-range-progress {
+    background: transparent;
     height: 0.5rem;
     border-radius: 9999px;
-    background: var(--slider-color);
   }
 
   .allocation-slider::-moz-range-thumb {
@@ -51,5 +88,13 @@
     border: 2px solid var(--color-surface);
     border-radius: 9999px;
     background: var(--slider-color);
+  }
+
+  @media (prefers-contrast: more) {
+    .allocation-slider {
+      --slider-blocked: var(--color-surface);
+      --slider-hatch: var(--color-ink);
+      --slider-tick: var(--color-ink);
+    }
   }
 }

--- a/app/helpers/scenarios_helper.rb
+++ b/app/helpers/scenarios_helper.rb
@@ -23,20 +23,4 @@ module ScenariosHelper
     others = scenario.ongoing_allocations.where.not(id: allocation.id).sum(:percentage)
     [ 100 - others, 0 ].max
   end
-
-  # The slider's max must never sit below the allocation's own current percentage —
-  # otherwise pre-existing over-allocated data (from before this cap existed) would
-  # render as if maxed out at the wrong position. It still blocks dragging any higher.
-  def allocation_slider_max(scenario, allocation)
-    [ remaining_ongoing_percentage(scenario, allocation), allocation.percentage.to_i ].max
-  end
-
-  # The slider's CSS fill (--slider-value) is a percentage of the *track*, not of the
-  # underlying value, so once max drops below 100 it must be rescaled or the colored
-  # fill and the native thumb position (which follows value/max) drift apart.
-  def allocation_slider_fill_percent(percentage, max)
-    return 0 if max.to_i.zero?
-
-    (percentage.to_f / max * 100).round(2)
-  end
 end

--- a/app/javascript/controllers/allocation_slider_controller.js
+++ b/app/javascript/controllers/allocation_slider_controller.js
@@ -19,8 +19,10 @@ export default class extends Controller {
     const dollar = Math.round((percent / 100) * this.ongoingAmountValue)
     const perpetuity = Math.round(dollar * this.payoutRateValue)
 
-    this.inputTarget.style.setProperty("--slider-value", `${percent}%`)
-    this.inputTarget.style.setProperty("--slider-limit", `${this.limitValue}%`)
+    // Unitless: the stylesheet scales these into the thumb's travel space.
+    this.inputTarget.style.setProperty("--slider-value", String(percent))
+    this.inputTarget.style.setProperty("--slider-limit", String(this.limitValue))
+    this.inputTarget.classList.toggle("allocation-slider--capped", this.limitValue < 100)
     this.percentTargets.forEach((el) => (el.textContent = `${percent}%`))
     this.dollarTargets.forEach((el) => (el.textContent = currency.format(dollar)))
     if (this.hasPerpetuityTarget) {

--- a/app/javascript/controllers/allocation_slider_controller.js
+++ b/app/javascript/controllers/allocation_slider_controller.js
@@ -11,18 +11,16 @@ export default class extends Controller {
   static values = {
     ongoingAmount: Number,
     payoutRate: Number,
+    limit: { type: Number, default: 100 },
   }
 
   update() {
-    const percent = Number(this.inputTarget.value)
-    const max = Number(this.inputTarget.max) || 100
+    const percent = this.clampedValue()
     const dollar = Math.round((percent / 100) * this.ongoingAmountValue)
     const perpetuity = Math.round(dollar * this.payoutRateValue)
 
-    // --slider-value fills the track (0-max), which is distinct from percent
-    // (0-100) once the slider's max is capped below 100 by remaining headroom.
-    const fillPercent = max > 0 ? (percent / max) * 100 : 0
-    this.inputTarget.style.setProperty("--slider-value", `${fillPercent}%`)
+    this.inputTarget.style.setProperty("--slider-value", `${percent}%`)
+    this.inputTarget.style.setProperty("--slider-limit", `${this.limitValue}%`)
     this.percentTargets.forEach((el) => (el.textContent = `${percent}%`))
     this.dollarTargets.forEach((el) => (el.textContent = currency.format(dollar)))
     if (this.hasPerpetuityTarget) {
@@ -31,6 +29,17 @@ export default class extends Controller {
   }
 
   save() {
+    this.clampedValue()
     this.inputTarget.form?.requestSubmit()
+  }
+
+  // The input's own max stays at 100 so its value and the CSS fill share one
+  // coordinate space; the remaining headroom is enforced here instead.
+  clampedValue() {
+    const percent = Math.min(Number(this.inputTarget.value), this.limitValue)
+    if (percent !== Number(this.inputTarget.value)) {
+      this.inputTarget.value = String(percent)
+    }
+    return percent
   }
 }

--- a/app/views/scenarios/_allocation.html.erb
+++ b/app/views/scenarios/_allocation.html.erb
@@ -52,10 +52,10 @@
               headroom the slider actually stops at has to be announced separately. %>
           <span id="<%= dom_id(allocation, :headroom) %>" class="sr-only"><%= slider_limit %>% remaining to allocate</span>
           <%= range_field_tag "allocation[percentage]", allocation.percentage, min: 0, max: 100, step: 1,
-                style: "--slider-color: #{color}; --slider-value: #{allocation.percentage.to_i}%; --slider-limit: #{slider_limit}%",
+                style: "--slider-color: #{color}; --slider-value: #{allocation.percentage.to_i}; --slider-limit: #{slider_limit}",
                 aria: { describedby: dom_id(allocation, :headroom) },
                 data: { allocation_slider_target: "input", action: "input->allocation-slider#update change->allocation-slider#save" },
-                class: "allocation-slider block" %>
+                class: [ "allocation-slider block", ("allocation-slider--capped" if slider_limit < 100) ] %>
         <% end %>
         <div class="flex items-baseline gap-3 shrink-0">
           <span class="w-10 text-right font-semibold text-ink tabular-nums" data-allocation-slider-target="percent"><%= allocation.percentage %>%</span>

--- a/app/views/scenarios/_allocation.html.erb
+++ b/app/views/scenarios/_allocation.html.erb
@@ -1,11 +1,12 @@
 <%# locals: (allocation:, scenario:, allocation_counter: 0) %>
 <% if allocation.ongoing? %>
   <% color = allocation_chart_color(allocation_counter) %>
-  <% slider_max = allocation_slider_max(scenario, allocation) %>
+  <% slider_limit = remaining_ongoing_percentage(scenario, allocation) %>
   <div data-controller="dialog">
     <div data-controller="allocation-slider"
          data-allocation-slider-ongoing-amount-value="<%= scenario.ongoing_giving_amount %>"
          data-allocation-slider-payout-rate-value="<%= Allocation::Ongoing::PERPETUITY_PAYOUT_RATE %>"
+         data-allocation-slider-limit-value="<%= slider_limit %>"
          class="rounded-lg border <%= allocation.greatest_community_need? ? "border-brand/30 bg-brand-tint" : "border-line-soft bg-surface" %> px-4 py-3 transition hover:shadow-sm">
       <div class="flex items-start justify-between gap-3">
         <% if allocation.greatest_community_need? %>
@@ -47,8 +48,12 @@
 
       <div class="mt-3 flex items-center gap-4">
         <%= form_with url: scenario_allocation_path(scenario, allocation), method: :patch, class: "flex-1 min-w-0 leading-none" do %>
-          <%= range_field_tag "allocation[percentage]", allocation.percentage, min: 0, max: slider_max, step: 1,
-                style: "--slider-color: #{color}; --slider-value: #{allocation_slider_fill_percent(allocation.percentage, slider_max)}%",
+          <%# The input's max stays at 100 (see allocation_slider_controller.js), so the
+              headroom the slider actually stops at has to be announced separately. %>
+          <span id="<%= dom_id(allocation, :headroom) %>" class="sr-only"><%= slider_limit %>% remaining to allocate</span>
+          <%= range_field_tag "allocation[percentage]", allocation.percentage, min: 0, max: 100, step: 1,
+                style: "--slider-color: #{color}; --slider-value: #{allocation.percentage.to_i}%; --slider-limit: #{slider_limit}%",
+                aria: { describedby: dom_id(allocation, :headroom) },
                 data: { allocation_slider_target: "input", action: "input->allocation-slider#update change->allocation-slider#save" },
                 class: "allocation-slider block" %>
         <% end %>

--- a/app/views/scenarios/_allocation_modal.html.erb
+++ b/app/views/scenarios/_allocation_modal.html.erb
@@ -22,10 +22,10 @@
         <%# max stays at 100 (see allocation_slider_controller.js); the headroom the
             slider actually stops at is announced through the description instead. %>
         <%= range_field_tag "allocation[percentage]", percentage, min: 0, max: 100, step: 1,
-              style: "--slider-color: #{color}; --slider-value: #{percentage.to_i}%; --slider-limit: #{remaining_percentage}%",
+              style: "--slider-color: #{color}; --slider-value: #{percentage.to_i}; --slider-limit: #{remaining_percentage}",
               aria: { describedby: "allocation_headroom_#{suffix}" },
               data: { allocation_slider_target: "input", action: "input->allocation-slider#update" },
-              class: "allocation-slider block mt-2" %>
+              class: [ "allocation-slider block mt-2", ("allocation-slider--capped" if remaining_percentage < 100) ] %>
       </div>
     <% else %>
       <div class="mt-6">

--- a/app/views/scenarios/_allocation_modal.html.erb
+++ b/app/views/scenarios/_allocation_modal.html.erb
@@ -4,7 +4,6 @@
 <% suffix = editing ? dom_id(allocation) : klass.model_name.element %>
 <% remaining_percentage = klass == Allocation::Ongoing ? remaining_ongoing_percentage(scenario, allocation) : nil %>
 <% percentage = allocation.percentage || [ 20, remaining_percentage.to_i ].min %>
-<% slider_max = klass == Allocation::Ongoing ? allocation_slider_max(scenario, allocation) : nil %>
 <% color ||= ScenariosHelper::CHART_COLORS.first %>
 <dialog data-dialog-target="dialog" data-action="click->dialog#backdropClose" class="m-auto w-full max-w-lg rounded-2xl p-0 shadow-lg backdrop:bg-[rgba(20,18,14,0.48)]">
   <%= form_with url: (editing ? scenario_allocation_path(scenario, allocation) : scenario_allocations_path(scenario)), method: (editing ? :patch : :post), class: "p-8" do |form| %>
@@ -14,14 +13,17 @@
     <%= render "scenarios/category_picker", allocation: allocation, scenario: scenario %>
 
     <% if klass == Allocation::Ongoing %>
-      <div class="mt-6" data-controller="allocation-slider">
+      <div class="mt-6" data-controller="allocation-slider" data-allocation-slider-limit-value="<%= remaining_percentage %>">
         <div class="flex items-center justify-between">
           <span class="text-sm text-ink-soft">Giving percentage %</span>
-          <span class="text-sm text-ink-faint"><%= remaining_percentage %>% remaining</span>
+          <span id="allocation_headroom_<%= suffix %>" class="text-sm text-ink-faint"><%= remaining_percentage %>% remaining</span>
         </div>
         <p class="mt-1 text-lg font-medium text-ink" data-allocation-slider-target="percent"><%= percentage %>%</p>
-        <%= range_field_tag "allocation[percentage]", percentage, min: 0, max: slider_max, step: 1,
-              style: "--slider-color: #{color}; --slider-value: #{allocation_slider_fill_percent(percentage, slider_max)}%",
+        <%# max stays at 100 (see allocation_slider_controller.js); the headroom the
+            slider actually stops at is announced through the description instead. %>
+        <%= range_field_tag "allocation[percentage]", percentage, min: 0, max: 100, step: 1,
+              style: "--slider-color: #{color}; --slider-value: #{percentage.to_i}%; --slider-limit: #{remaining_percentage}%",
+              aria: { describedby: "allocation_headroom_#{suffix}" },
               data: { allocation_slider_target: "input", action: "input->allocation-slider#update" },
               class: "allocation-slider block mt-2" %>
       </div>


### PR DESCRIPTION
Fixes https://github.com/rubyforgood/community_foundation/issues/116 (see video there for current behavior)

- Styles the sliders so that they are always maxed out of 100 and don't dynamically adjust
- Grays out the remaining percentage



https://github.com/user-attachments/assets/62922d52-ee1f-467a-9c3e-04db6ea17308


